### PR TITLE
chore(infra): bump Node from 20 to 24 LTS (supersedes #112)

### DIFF
--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   # Quick checks that fail fast

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   e2e:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
   K6_VERSION: 'v0.52.0'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for ScrumQuest
 # Stage 1: Build
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ ENV NODE_OPTIONS="--max-old-space-size=1024"
 RUN npm run build
 
 # Stage 2: Production
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Move all Node toolchain references from `20` to `24 LTS` (Krypton). Counter-proposal to #112, which bumped to Node 26.

## Why not #112 (Node 26)?

| | Node 20 (today) | Node 24 (this PR) | Node 26 (#112) |
|---|---|---|---|
| Status | LTS, **maintenance-only** since April 2026 | LTS (Krypton) since Oct 2025 | **Current**, released 2026-05-05 |
| LTS start | Oct 2023 | Oct 2025 | Oct 2026 (4 months away) |
| Latest | v20.x (security patches only) | v24.15.0 (well-validated) | v26.1.0 (week-old release) |
| Production fit | Aging out | Yes | No — not LTS until Oct |

Dependabot's image-tag follower doesn't distinguish LTS from Current. We want LTS for prod.

## Changes

- `Dockerfile` — builder + runner stages `node:20-alpine` → `node:24-alpine`
- `.github/workflows/ci.yml` — `NODE_VERSION: "20"` → `"24"` (covers 6 jobs)
- `.github/workflows/e2e.yml` — same
- `.github/workflows/load-tests.yml` — same (3 jobs)
- `.github/workflows/api-contracts.yml` — 3 hardcoded `node-version: '20'` → `'24'`
- `.github/workflows/release.yml` — `node-version: "20"` → `"24"`

## Risk assessment

- **Native modules:** Only `bufferutil`, which uses N-API prebuilds (version-agnostic). No rebuild needed.
- **Engines constraints:** Scanned all installed `node_modules`; no `engines.node` upper bound blocks Node 24.
- **Test runners:** Vitest 4.x and Playwright 1.60 both officially support Node 24.
- **TypeScript:** No change to tsc version; tsc compiles JS that runs on the target.
- **Known Node 22→24 gotcha:** `--experimental-vm-modules` flag was tightened; we don't use it.

CI will validate the end-to-end build on Node 24 (it's what the workflows now run on).

## After merge

Close #112 with a comment pointing here.

## Test plan

- [ ] CI green on the new Node version (especially Build + Test + Validate Migrations)
- [ ] Docker image builds (CI image build job)
- [ ] Deployed-preview smoke test if you have one

🤖 Generated with [Claude Code](https://claude.com/claude-code)