### PR TITLE
chore(ci): fork-PR guard — route untrusted PRs to ubuntu-latest

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   accessibility:
     name: Accessibility Tests (axe-core)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble
       options: --init --ipc=host

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   validate-specs:
     name: Validate API Specs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +42,7 @@ jobs:
 
   type-drift:
     name: Check Type Generation Drift
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     steps:
       - uses: actions/checkout@v4
 
@@ -69,7 +69,7 @@ jobs:
 
   contract-tests:
     name: Contract Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     needs: validate-specs
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
   # Gate job for branch protection
   api-contracts-success:
     name: API Contracts Success
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     needs: [validate-specs, type-drift, contract-tests]
     if: always()
     steps:

--- a/.github/workflows/auto-rollback-monitor.yml
+++ b/.github/workflows/auto-rollback-monitor.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   health-check:
     name: Post-Deploy Health Check
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     # Only run if deploy succeeded
     if: github.event.workflow_run.conclusion == 'success'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   # Quick checks that fail fast
   lint-and-typecheck:
     name: Lint & Type Check
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:
@@ -56,7 +56,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
     permissions:
       contents: read
@@ -94,7 +94,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
     needs: [lint-and-typecheck, test]
 
@@ -123,7 +123,7 @@ jobs:
 
   security-audit:
     name: Security Audit
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
     # Block PRs on high/critical vulnerabilities (configured in .audit-ci.json)
 
@@ -145,7 +145,7 @@ jobs:
 
   license-check:
     name: License Check
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:
@@ -166,7 +166,7 @@ jobs:
 
   validate-migrations:
     name: Validate Migrations
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
 
     services:
@@ -227,7 +227,7 @@ jobs:
   # blue-green deploy helpers from rotting between deploys.
   deploy-scripts:
     name: Deploy script lint + tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
 
     steps:
@@ -248,7 +248,7 @@ jobs:
   # Summary job for branch protection rules
   ci-success:
     name: CI Success
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
     needs: [lint-and-typecheck, test, build, security-audit, license-check, validate-migrations, deploy-scripts]
     if: always()
@@ -270,7 +270,7 @@ jobs:
 
   update-coverage-badge:
     name: Update Coverage Badge
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     needs: [test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   cleanup-runs:
     name: Clean Old Workflow Runs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:
@@ -28,7 +28,7 @@ jobs:
 
   cleanup-caches:
     name: Clean Old Caches
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   cleanup-packages:
     name: Clean Old Package Versions
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto-Merge Dependabot PRs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     # Only run for Dependabot PRs

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   deploy-staging:
     name: Deploy to Staging
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     environment:
@@ -77,7 +77,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to Production
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch'
     environment:
@@ -118,7 +118,7 @@ jobs:
 
   smoke-test:
     name: Smoke Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
     needs: [deploy-staging, deploy-prod]
     if: always() && (needs.deploy-staging.result == 'success' || needs.deploy-prod.result == 'success')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   build-and-push:
     name: Build & Push
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
 
     outputs:
@@ -105,7 +105,7 @@ jobs:
 
   scan:
     name: Security Scan
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
     needs: build-and-push
     if: github.event_name != 'pull_request'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   e2e:
     name: Playwright E2E Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   label:
     name: Auto-label PRs
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   http-load-tests:
     name: HTTP Load Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
 
     steps:
@@ -115,7 +115,7 @@ jobs:
 
   websocket-load-tests:
     name: WebSocket Load Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 15
 
     steps:
@@ -192,7 +192,7 @@ jobs:
 
   idle-connection-test:
     name: Idle Connection Test
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
     if: github.event.inputs.run_idle_test == 'true' || github.event_name == 'schedule'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   pr-title:
     name: Validate PR Title
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   size-label:
     name: PR Size Label
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
 
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   files-changed:
     name: Detect Changed Files
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
 
     outputs:

--- a/.github/workflows/provision-vps-secrets.yml
+++ b/.github/workflows/provision-vps-secrets.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   provision:
     name: Append NPM admin creds to VPS .env
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   release:
     name: Create Release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
 
     outputs:
@@ -100,7 +100,7 @@ jobs:
 
   docker-release:
     name: Docker Release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
     needs: release
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   rate-limit-check:
     name: Check Rate Limits
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     outputs:
       rate-check: ${{ steps.rate-check.outputs.rate-check }}
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   rollback:
     name: Rollback ${{ github.event.inputs.environment }}
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     needs: rate-limit-check
     # Environment protection - production requires approval
     environment:
@@ -304,7 +304,7 @@ jobs:
 
   audit-and-notify:
     name: Record Audit Trail
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     needs: rollback
     if: needs.rollback.outputs.rollback-success == 'true' && github.event.inputs.dry_run == 'false'
     permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   gitleaks:
     name: Secret Detection
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     name: Mark Stale
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   visual-tests:
     name: Visual Regression Tests
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble
       options: --init --ipc=host


### PR DESCRIPTION
## Summary

Stacked on top of #118. Replaces the static \`runs-on: [self-hosted, Linux, X64]\` introduced by #118 with a conditional expression that routes by PR source:

```yaml
runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted", "Linux", "X64"]') }}'
```

## Decision logic

| Event | `head.repo.fork` | Resolves to |
|---|---|---|
| `push` to `main` | `null` (falsy) | self-hosted ✅ |
| `pull_request` from same repo | `false` | self-hosted ✅ |
| **`pull_request` from a fork** | **`true`** | **ubuntu-latest** ⛔ no NAS |
| `workflow_dispatch` / `schedule` / `release` | `null` | self-hosted ✅ |

## Why this on top of the UI approval gate

The GitHub Settings → Actions → "Require approval for all outside collaborators" setting is the primary defense (already being set as part of this work). This PR is belt-and-suspenders:

- UI setting can be accidentally relaxed by a maintainer click. Repo files cannot — they're in git, in PR history, reviewable.
- Even if the UI gate is bypassed (compromised maintainer account, GitHub bug), this PR ensures fork code is structurally incapable of selecting the self-hosted runner. It will land on `ubuntu-latest` regardless.

## Friendly to external contributors

External PRs still get full CI feedback — just on GitHub-hosted runners. They don't see "no CI ran" or skipped checks. The cost is your GitHub Actions minutes for external-PR CI, but you're spending those minutes you'd have spent anyway if not for the NAS runner.

## Validation

- All 42 \`runs-on\` lines replaced across 19 active workflow files
- All files validated to parse as YAML after the change
- Expression syntax matches GitHub's documented \`fromJSON\` + ternary pattern

## Test plan

- [ ] After merge, open a same-repo PR — confirm jobs land on \`synology-xavisavvy\` runner
- [ ] After merge, ask a friend to fork + open a PR — confirm those jobs land on a \`GitHub Actions\` runner (\`ubuntu-latest\`), not the NAS
- [ ] \`workflow_dispatch\` from main still hits the NAS

## Merge order

This PR's base is \`chore/move-ci-to-synology-runner\` (#118). The intent is:

1. Merge #118 first (puts the static self-hosted on main; the NAS is the default)
2. GitHub auto-rebases this PR's base to \`main\`
3. Merge this PR (adds the fork-PR guard)

If you'd rather collapse them into one PR, I can rebase + force-push this branch onto main and squash both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)