### PR TITLE
chore(ci): run e2e inside the official Playwright container image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,13 @@ jobs:
     name: Playwright E2E Tests
     runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
-
+    # Run the job inside Microsoft's official Playwright image — chromium,
+    # firefox and every system library Playwright needs ship preinstalled.
+    # Avoids `--with-deps` which calls `sudo apt-get` and fails on Synology
+    # DSM (no apt, no passwordless sudo). Pin the image tag to match the
+    # @playwright/test version in package.json; bump both together.
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +53,8 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+        # No --with-deps: system libs already in the playwright image.
+        run: npx playwright install chromium firefox
 
       - name: Run Playwright tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary

Stacks on #119. Switches the Playwright job to run *inside* \`mcr.microsoft.com/playwright:v1.60.0-jammy\` so we don't need apt or sudo on the self-hosted Synology runner.

## Why

\`npx playwright install --with-deps\` fails on DSM:

\`\`\`
BEWARE: your OS is not officially supported by Playwright;
        installing dependencies for ubuntu24.04-x64 as a fallback.
sudo: a terminal is required to read the password
\`\`\`

DSM doesn't use \`apt\`, and the runner user has no passwordless \`sudo\` (which is the correct security posture). Installing the system libs natively on DSM is brittle and DSM-version-coupled.

The Playwright Docker image already ships chromium + firefox + every system library Playwright needs. Running the job inside it is the canonical Microsoft-recommended approach.

## Changes (1 file)

\`.github/workflows/e2e.yml\`:
- Add \`container: mcr.microsoft.com/playwright:v1.60.0-jammy\` to the e2e job
- Drop \`--with-deps\` from the browser-install command (deps already present)
- Inline comment explaining the version pinning rule (image tag tracks \`@playwright/test\` version in package.json)

## Stacking note

This PR's base is \`chore/lock-self-hosted-to-same-repo-prs\` (#119), which itself bases on #118. After #118 + #119 land on main, this PR auto-rebases and the diff against main becomes the three lines above. If you'd rather collapse this into one PR with the others, I can rebase + merge in any order.

## Test plan

- [ ] After merge (and after Docker-group fix on the NAS), the e2e job pulls the playwright image and runs tests
- [ ] No "sudo password" prompts in the install step
- [ ] Playwright report artifact uploads from inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)