### PR TITLE
chore(ci): remap CI postgres service to host port 15432 (self-hosted runner)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   accessibility:
     name: Accessibility Tests (axe-core)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble
       options: --init --ipc=host

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   validate-specs:
     name: Validate API Specs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +42,7 @@ jobs:
 
   type-drift:
     name: Check Type Generation Drift
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -69,7 +69,7 @@ jobs:
 
   contract-tests:
     name: Contract Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: validate-specs
     steps:
       - uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
   # Gate job for branch protection
   api-contracts-success:
     name: API Contracts Success
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [validate-specs, type-drift, contract-tests]
     if: always()
     steps:

--- a/.github/workflows/auto-rollback-monitor.yml
+++ b/.github/workflows/auto-rollback-monitor.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   health-check:
     name: Post-Deploy Health Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     # Only run if deploy succeeded
     if: github.event.workflow_run.conclusion == 'success'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   # Quick checks that fail fast
   lint-and-typecheck:
     name: Lint & Type Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:
@@ -56,7 +56,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -94,7 +94,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     needs: [lint-and-typecheck, test]
 
@@ -123,7 +123,7 @@ jobs:
 
   security-audit:
     name: Security Audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     # Block PRs on high/critical vulnerabilities (configured in .audit-ci.json)
 
@@ -145,7 +145,7 @@ jobs:
 
   license-check:
     name: License Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:
@@ -166,7 +166,7 @@ jobs:
 
   validate-migrations:
     name: Validate Migrations
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
 
     services:
@@ -227,7 +227,7 @@ jobs:
   # blue-green deploy helpers from rotting between deploys.
   deploy-scripts:
     name: Deploy script lint + tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
 
     steps:
@@ -248,7 +248,7 @@ jobs:
   # Summary job for branch protection rules
   ci-success:
     name: CI Success
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
     needs: [lint-and-typecheck, test, build, security-audit, license-check, validate-migrations, deploy-scripts]
     if: always()
@@ -270,7 +270,7 @@ jobs:
 
   update-coverage-badge:
     name: Update Coverage Badge
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: [test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
         ports:
-          - 5432:5432
+          # Host port 15432 (not 5432) to avoid collision with DSM's native
+          # Postgres on the self-hosted Synology runner. Inside the service
+          # container Postgres still listens on 5432; the mapping rewrites
+          # only the host-side port that the job's `localhost:NNNNN` URL hits.
+          - 15432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -198,12 +202,12 @@ jobs:
 
       - name: Apply migrations to fresh database
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:15432/test
         run: npm run db:migrate
 
       - name: Check for schema drift
         env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
+          DATABASE_URL: postgresql://postgres:postgres@localhost:15432/test
         run: |
           # Generate would create files if schema changed without migration
           npx drizzle-kit generate

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   cleanup-runs:
     name: Clean Old Workflow Runs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:
@@ -28,7 +28,7 @@ jobs:
 
   cleanup-caches:
     name: Clean Old Caches
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   cleanup-packages:
     name: Clean Old Package Versions
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto-Merge Dependabot PRs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     # Only run for Dependabot PRs

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   deploy-staging:
     name: Deploy to Staging
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     environment:
@@ -77,7 +77,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to Production
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch'
     environment:
@@ -118,7 +118,7 @@ jobs:
 
   smoke-test:
     name: Smoke Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     needs: [deploy-staging, deploy-prod]
     if: always() && (needs.deploy-staging.result == 'success' || needs.deploy-prod.result == 'success')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   build-and-push:
     name: Build & Push
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
 
     outputs:
@@ -105,7 +105,7 @@ jobs:
 
   scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     needs: build-and-push
     if: github.event_name != 'pull_request'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   e2e:
     name: Playwright E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   label:
     name: Auto-label PRs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   http-load-tests:
     name: HTTP Load Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
 
     steps:
@@ -115,7 +115,7 @@ jobs:
 
   websocket-load-tests:
     name: WebSocket Load Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
 
     steps:
@@ -192,7 +192,7 @@ jobs:
 
   idle-connection-test:
     name: Idle Connection Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     if: github.event.inputs.run_idle_test == 'true' || github.event_name == 'schedule'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   pr-title:
     name: Validate PR Title
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   size-label:
     name: PR Size Label
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
 
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   files-changed:
     name: Detect Changed Files
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
 
     outputs:

--- a/.github/workflows/provision-vps-secrets.yml
+++ b/.github/workflows/provision-vps-secrets.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   provision:
     name: Append NPM admin creds to VPS .env
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
 
     outputs:
@@ -100,7 +100,7 @@ jobs:
 
   docker-release:
     name: Docker Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     needs: release
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   rate-limit-check:
     name: Check Rate Limits
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     outputs:
       rate-check: ${{ steps.rate-check.outputs.rate-check }}
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   rollback:
     name: Rollback ${{ github.event.inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: rate-limit-check
     # Environment protection - production requires approval
     environment:
@@ -304,7 +304,7 @@ jobs:
 
   audit-and-notify:
     name: Record Audit Trail
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     needs: rollback
     if: needs.rollback.outputs.rollback-success == 'true' && github.event.inputs.dry_run == 'false'
     permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   gitleaks:
     name: Secret Detection
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     name: Mark Stale
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   visual-tests:
     name: Visual Regression Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble
       options: --init --ipc=host


### PR DESCRIPTION
## Summary

Top of stack on the self-hosted runner enablement work (#118 → #119 → #120 → #121). Remaps the \`services: postgres\` host port from 5432 → 15432 to avoid colliding with DSM's native Postgres on the Synology runner.

## Why

The Synology NAS ships a native Postgres (\`/usr/bin/postgres -D /var/services/pgsql\`, running as \`postgres\` user since Mar 25) bound to 127.0.0.1:5432. The CI workflow's host-port mapping tries to bind 0.0.0.0:5432 → \`bind: address already in use\` → \`Docker start fail with exit code 1\` → \`Initialize containers\` fails.

GitHub-hosted runners get a fresh VM each job so 5432 is always free; self-hosted has whatever's on the host.

## Change

\`.github/workflows/ci.yml\` (validate-migrations job):
- \`ports: - 5432:5432\` → \`ports: - 15432:5432\` (host:container)
- Two \`DATABASE_URL\` env values updated from \`localhost:5432\` → \`localhost:15432\`
- Inline comment explaining the remap

## Why 15432 specifically

Common convention for "non-standard postgres" in dev/CI. Unlikely to collide with anything else on the NAS.

## Test plan

- [ ] After merge, the Validate Migrations job's \`Initialize containers\` step succeeds
- [ ] \`npm run db:migrate\` connects to \`localhost:15432\` and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)