### PR TITLE
chore(ci): run Playwright container as actionsrunner uid

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,14 @@ jobs:
     # @playwright/test version in package.json; bump both together.
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-jammy
+      # Run the container as the self-hosted runner's UID:GID so files
+      # written into the mounted workspace are owned by `actionsrunner`,
+      # not by root inside the container. Without this, root-owned files
+      # leak onto the host workspace and break the NEXT job's
+      # actions/checkout with EACCES on git clean. Matches `id actionsrunner`
+      # on synology-xavisavvy: uid=1030, gid=100. Adjust if the runner host
+      # or user changes.
+      options: --user 1030:100
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds \`options: --user 1030:100\` to the Playwright container so it runs as the self-hosted runner's user (actionsrunner) instead of root.

## Why

Today's E2E job failure on main shows the root cause clearly:

\`\`\`
fatal: Unable to create '/volume1/actions-runner/.../scrum-monsters/.git/index.lock': Permission denied
EACCES: permission denied, unlink '.../.argocd-rollback/.gitkeep'
\`\`\`

The Playwright container was running as root inside, so anything it wrote into the mounted workspace ended up owned by root on the host filesystem. The Docker workflow (which runs *natively* as \`actionsrunner\`, uid 1030) then can't \`git clean\` the workspace on its next checkout.

This is a recurring class of bug with self-hosted runners and \`container:\` directives — every container job that writes to the workspace needs to run as the host runner UID.

## Companion cleanup (one-time, on the NAS)

After this lands, also run on heimdall once more to clear the existing root-owned files from before this fix:

\`\`\`bash
sudo rm -rf /volume1/actions-runner/scrum-monsters/_work/scrum-monsters
\`\`\`

Future container jobs won't recreate them with bad ownership.

## Risk

Minimal. uid 1030 / gid 100 are the runner user; mounted volume + npm cache directories were already owned by that uid (just got contaminated by root-owned writes). The Playwright image runs the test runner as a non-root user just fine.

## Test plan

- [ ] E2E workflow checks out cleanly on main after merge
- [ ] Docker workflow's checkout no longer EACCES
- [ ] Inside the e2e job, \`whoami\` reports something other than \`root\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)