### PR TITLE
ci: gate heavy Playwright workflows on a fast typecheck pre-check

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -17,9 +17,33 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  NODE_VERSION: "24"
+
 jobs:
+  # Cheap typecheck gate (~30-60s) so we don't spin up the Playwright
+  # container (~3-5 min) when a TypeScript error would have failed the
+  # PR anyway. The Playwright job below `needs: pre-check`.
+  pre-check:
+    name: Pre-check (typecheck)
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run check
+
   accessibility:
     name: Accessibility Tests (axe-core)
+    needs: pre-check
     runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,8 +28,29 @@ env:
   NODE_VERSION: "24"
 
 jobs:
+  # Cheap typecheck gate (~30-60s) so we don't spin up the Playwright
+  # container (~6-8 min) when a TypeScript error would have failed the
+  # PR anyway. e2e below `needs: pre-check`.
+  pre-check:
+    name: Pre-check (typecheck)
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run check
+
   e2e:
     name: Playwright E2E Tests
+    needs: pre-check
     runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     timeout-minutes: 30
     # Run the job inside Microsoft's official Playwright image - chromium,

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -17,9 +17,33 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  NODE_VERSION: "24"
+
 jobs:
+  # Cheap typecheck gate (~30-60s) so we don't spin up the Playwright
+  # container (~5 min) when a TypeScript error would have failed the
+  # PR anyway. visual-tests below `needs: pre-check`.
+  pre-check:
+    name: Pre-check (typecheck)
+    runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run check
+
   visual-tests:
     name: Visual Regression Tests
+    needs: pre-check
     runs-on: '${{ fromJSON(github.event.pull_request.head.repo.fork && ''["ubuntu-latest"]'' || ''["self-hosted", "Linux", "X64"]'') }}'
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble


### PR DESCRIPTION
## Summary
Adds a `pre-check` job (npm ci + npm run check, ~30-60s) at the top of e2e.yml, accessibility.yml, and visual-regression.yml. The Playwright job in each workflow now `needs: pre-check`, so when a TypeScript error sneaks into a PR the Playwright container (~3-8 min each, ×3 workflows) never starts.

## Trade-off
- Happy path: adds ~60s of sequential latency (pre-check then heavy job) instead of running them in parallel.
- Failure path: saves roughly 6-8 min × 3 workflows = 15-25 min of runner time per typecheck break, plus eliminates the noise of three Playwright failures that are all actually the same TS error.

Pre-check runs WITHOUT the Playwright container (plain Node) so its own setup is fast.

## Test plan
- [ ] CI passes on this PR
- [ ] Manually verify: push a deliberate TS error in a follow-up branch and confirm Playwright workflows abort at the pre-check step instead of spinning up the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)