### PR TITLE
fix(ci): replace vi.importActual('crypto') with minimal mock in logger.test.ts

### DIFF
--- a/server/logger.test.ts
+++ b/server/logger.test.ts
@@ -73,15 +73,15 @@ async function loadLoggerModule(options?: {
   });
 
   const randomBytes = vi.fn(() => Buffer.from(options?.randomBytesHex ?? '0011223344556677', 'hex'));
-  vi.doMock('crypto', async () => {
-    const actual = await vi.importActual<typeof import('crypto')>('crypto');
-
-    return {
-      ...actual,
-      randomBytes,
-      default: actual,
-    };
-  });
+  // Minimal mock — logger.ts only imports `randomBytes` from `crypto`.
+  // Avoid `vi.importActual('crypto')` because Vite's resolver treats Node
+  // built-ins as `__vite-browser-external` placeholders, which crash with
+  // `ERR_INVALID_ARG_VALUE` ("must be a file URL"). If logger.ts grows to
+  // import more from crypto, extend this mock surface explicitly.
+  vi.doMock('crypto', () => ({
+    randomBytes,
+    default: { randomBytes },
+  }));
   vi.doMock('pino', () => {
     const pinoMock = vi.fn((config: Record<string, unknown>) => {
       captured.config = config;


### PR DESCRIPTION
## Summary

PR #123's Copilot-generated test file used `vi.importActual('crypto')` to spread the real module into a mock. Vitest's resolver routes Node built-ins through Vite, which represents `crypto` as `__vite-browser-external:crypto` — not a real file URL — crashing with \`ERR_INVALID_ARG_VALUE\` when `importActual` tries to load it.

6 tests in `server/logger.test.ts` failed continuously after #123 merged via \`--admin\` bypass. Husky pre-commit runs full \`npm test\`, so every subsequent commit was blocked.

## Fix

`logger.ts` only imports `randomBytes` from crypto. Replace the spread-actual pattern with a minimal explicit mock. If logger.ts grows new crypto imports, extend the mock surface.

## Test plan

- [x] `npx vitest run server/logger.test.ts` — all 6 tests pass
- [x] Full `npm test` — 736/736 passing
- [ ] CI green

## Follow-up (not in this PR)

- Branch protection should disallow `--admin` bypass on test failures (#123 admin-merged with these tests already red).
- Husky pre-commit running full `npm test` invites `--no-verify` pressure when one file breaks. Consider scoping to lint + typecheck + \`vitest related\` for staged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)