### PR TITLE
fix(estimation): show vote indicators in battle UI

### DIFF
--- a/client/src/lib/socket/eventHandlers.ts
+++ b/client/src/lib/socket/eventHandlers.ts
@@ -261,7 +261,21 @@ export function setupEventHandlers(socket: Socket): void {
     if (processed) {
       const { currentLobby, setLobby, requestBattleRemount } = useGameState.getState();
       if (currentLobby) {
-        setLobby({ ...currentLobby, currentTicket: data.currentTicket as JiraTicket });
+        // Reset per-ticket vote state on the client. Server resets these in
+        // gameState.proceedNextLevel (see gameState.ts:858/889/929/1154) but
+        // the fine-grained session:ticket_advanced payload only carries
+        // currentTicket — without this reset, players stay marked as
+        // hasSubmittedScore=true from the previous ticket and the vote-
+        // indicator UI is wrong for the new ticket.
+        setLobby({
+          ...currentLobby,
+          currentTicket: data.currentTicket as JiraTicket,
+          players: currentLobby.players.map(p => ({
+            ...p,
+            hasSubmittedScore: false,
+            currentScore: undefined,
+          })),
+        });
         // Phase 42-02b Task 2: BattleScreen mid-battle ticket-change remount
         // (formerly handled in GamePage.tsx:201-216 lobby_updated handler).
         if (currentLobby.gamePhase === 'battle' && typeof requestBattleRemount === 'function') {

--- a/server/websocket.ts
+++ b/server/websocket.ts
@@ -934,9 +934,19 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
         const player = lobby.players.find(p => p.id === playerId);
         if (player) {
           socket.to(lobby.id).emit('score_submitted', { playerId, team: player.team });
+
+          // Emit fine-grained estimation:vote_cast so all clients (including
+          // the voter) update their hasSubmittedScore flag and render the vote
+          // indicator. The legacy `submit_score` path doesn't go through
+          // EstimationManager.castVote (which is what emits this event for the
+          // newer ranked-vote path), so we emit it here directly.
+          emitFineGrained(lobby.id, 'estimation:vote_cast', {
+            playerId,
+            team: player.team,
+            hasVoted: true,
+          });
         }
 
-        // Removed lobby_updated: estimation:vote_cast event emitted by estimationManager
         
         // Check if all scores submitted and reveal
         if (lobby.gamePhase === 'reveal') {


### PR DESCRIPTION
## Summary

Two gaps caused vote indicators to be missing/stale during the battle phase. Reporter saw the UI flip to "waiting for others" after voting, but no indicator was shown (not even for the voter).

- **Server bug**: `submit_score` handler called `gameState.submitScore` directly and never emitted `estimation:vote_cast`. The comment in `websocket.ts:939` claimed `estimationManager` would emit it, but the legacy `submit_score` path bypasses `EstimationManager.castVote` entirely. Result: no client (including the voter) ever marked `hasSubmittedScore=true`, so the per-team progress block stayed at `0 / N` after voting. Fix: emit `estimation:vote_cast` via `emitFineGrained` from the `submit_score` handler.

- **Client bug**: `session:ticket_advanced` handler only updated `currentTicket` and did not reset `hasSubmittedScore`/`currentScore` per-player. Server resets these in `gameState.proceedNextLevel` (lines 858/889/929/1154) but the fine-grained payload carries only the new ticket. Fix: reset both fields on every player when handling `session:ticket_advanced`.

## Test plan

- [ ] Solo lobby: start battle, vote — verify team progress shows `1 / 1` and "Ready" immediately, before phase advances to reveal.
- [ ] Two-player lobby: P1 votes — both clients show `1 / 2`; P2 votes — both show `2 / 2` then reveal.
- [ ] Multi-ticket battle: after advancing to next ticket via `next_level`, verify indicators reset to `0 / N` on all clients and the new ticket accepts fresh votes.
- [ ] Existing `EstimationManager` ranked-vote path (separate from `submit_score`) still functions — `estimation:vote_cast` is now emitted by two paths but both go through the same client handler which is idempotent (just sets `hasSubmittedScore: true`).