### PR TITLE
fix(server): route start_battle through avatar_selection phase

### DIFF
--- a/server/websocket.ts
+++ b/server/websocket.ts
@@ -103,6 +103,11 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
   // Pass the io instance to GameState for emitting events
   setGameStateIO(io);
 
+  // Tracks which players have explicitly confirmed an avatar during the
+  // avatar_selection phase, keyed by lobbyId. Reset whenever the lobby
+  // (re)enters avatar_selection via start_battle.
+  const avatarSelections = new Map<string, Set<string>>();
+
   // Initialize ClientEventEmitter for fine-grained event delivery
   const clientEventEmitter = initializeClientEventEmitter(io);
   socketLogger.info('ClientEventEmitter initialized for fine-grained events');
@@ -524,6 +529,61 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
         (emitter as any).sequencer.bufferEvent(lobby.id, seq, 'session:avatar_selected', payload);
         io.to(lobby.id).emit('session:avatar_selected', payload);
       }
+
+      // If we're in the avatar_selection phase, record this player's
+      // confirmation. Once every active (developer/qa) player has confirmed,
+      // advance the lobby into battle. Spectators don't gate the transition.
+      if (lobby.gamePhase === 'avatar_selection') {
+        let selected = avatarSelections.get(lobby.id);
+        if (!selected) {
+          selected = new Set<string>();
+          avatarSelections.set(lobby.id, selected);
+        }
+        const confirmedIds = selected;
+        confirmedIds.add(playerId);
+
+        const activePlayers = lobby.players.filter(
+          p => p.team === 'developers' || p.team === 'qa'
+        );
+        const allSelected =
+          activePlayers.length > 0 &&
+          activePlayers.every(p => confirmedIds.has(p.id));
+
+        if (allSelected) {
+          gameLogger.info(
+            { lobbyId: lobby.id, activeCount: activePlayers.length },
+            'All active players selected avatars - starting battle'
+          );
+
+          // Find the host to drive gameState.startBattle (it asserts host).
+          const host = lobby.players.find(p => p.isHost);
+          if (!host) {
+            gameLogger.warn({ lobbyId: lobby.id }, 'No host found when advancing to battle');
+            return;
+          }
+
+          const result = gameState.startBattle(host.id, lobby.tickets);
+          avatarSelections.delete(lobby.id);
+
+          if (!result) {
+            gameLogger.warn({ lobbyId: lobby.id }, 'startBattle returned null after avatar selection');
+            return;
+          }
+          if ('error' in result) {
+            gameLogger.warn({ error: result.error, lobbyId: lobby.id }, 'Battle start error post-avatar-selection');
+            io.to(lobby.id).emit('game_error', { message: result.error });
+            return;
+          }
+
+          const { lobby: updatedLobby, boss } = result;
+          io.to(updatedLobby.id).emit('battle_started', { lobby: updatedLobby, boss });
+          eventBus.emit('session:phase_changed', {
+            lobbyId: updatedLobby.id,
+            oldPhase: 'avatar_selection',
+            newPhase: 'battle',
+          });
+        }
+      }
     });
 
     socket.on('assign_team', ({ playerId: targetPlayerId, team }) => {
@@ -901,25 +961,32 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
         return;
       }
 
-      gameLogger.info({ lobbyId: lobby.id, ticketCount: lobby.tickets.length }, 'Starting battle');
-      const result = gameState.startBattle(playerId, lobby.tickets);
-      if (result) {
-        if ('error' in result) {
-          // Send error message to the client
-          gameLogger.warn({ error: result.error }, 'Battle start error');
-          socket.emit('game_error', { message: result.error });
-        } else {
-          const { lobby: updatedLobby, boss } = result;
+      gameLogger.info({ lobbyId: lobby.id, ticketCount: lobby.tickets.length }, 'Host initiated battle - entering avatar selection');
 
-          gameLogger.info({ lobbyId: updatedLobby.id }, 'Battle started successfully');
-          // Removed lobby_updated: battle_started event contains lobby
-
-          // Start the battle (synchronous - relies on socket.io event ordering)
-          io.to(updatedLobby.id).emit('battle_started', { lobby: updatedLobby, boss });
-        }
-      } else {
-        gameLogger.warn('startBattle returned null/undefined');
+      // Validate active players exist BEFORE entering avatar_selection so the
+      // host gets a synchronous error instead of being stranded in a phase
+      // that can never complete.
+      const hasActivePlayers = lobby.players.some(p => p.team === 'developers' || p.team === 'qa');
+      if (!hasActivePlayers) {
+        socket.emit('game_error', {
+          message: 'Cannot start battle: At least one Developer or QA team member is required to participate in estimation battles. Please assign players to active teams first.',
+        });
+        return;
       }
+
+      // Transition lobby into avatar_selection. The actual battle start
+      // (gameState.startBattle + battle_started emit) is deferred until every
+      // active (non-spectator) player has confirmed an avatar via
+      // `select_avatar` below.
+      const oldPhase = lobby.gamePhase;
+      lobby.gamePhase = 'avatar_selection';
+      avatarSelections.set(lobby.id, new Set<string>());
+
+      eventBus.emit('session:phase_changed', {
+        lobbyId: lobby.id,
+        oldPhase,
+        newPhase: 'avatar_selection',
+      });
     });
 
     socket.on('submit_score', ({ score }) => {


### PR DESCRIPTION
## Summary
- `start_battle` previously called `gameState.startBattle()` which set `lobby.gamePhase = 'battle'` directly, bypassing `avatar_selection` entirely. Players never saw the avatar picker and entered combat stuck on the default `warrior` avatar that `SessionManager.addPlayer` pre-seeds.
- `start_battle` now transitions the lobby into `avatar_selection` and emits `session:phase_changed`; `select_avatar` accumulates confirmations in a per-lobby `Set` and, once every developer/qa player has confirmed, runs `gameState.startBattle()` + emits `battle_started` and the `avatar_selection -> battle` phase change.
- Client-side routing was already correct (`GamePage.tsx:324` renders `<AvatarSelection />` when `phase === 'avatar_selection'`); no client changes required.

## Root cause
The dead-code paths in `server/gameState.ts` (`startGame()` at L1109 and `proceedToNextPhase()` at L1129) knew how to set `avatar_selection`, but nothing in `server/websocket.ts` ever invoked them — `start_battle` (L865) went straight to `gameState.startBattle()` (L785) which writes `gamePhase = 'battle'` in one step (L805).

## Test plan
- [ ] Manual: host creates lobby, joins as a second player, host clicks Start Battle. Both clients should now see the avatar selection screen.
- [ ] Manual: both players click Confirm Avatar. Both should advance to the battle screen with their chosen class.
- [ ] Manual: spectator-only second client should not block the host from proceeding once the host confirms.
- [ ] Manual: clicking Start Battle with zero developers/qa surfaces the existing `game_error` toast and does NOT enter avatar_selection.
- [ ] Automated: existing `e2e/battle.spec.ts` already tolerates `avatar_selection` as an intermediate state.

Note: `server/logger.test.ts` is failing deterministically on `main` (vitest crypto-mock infra issue). Confirmed unrelated via `git stash` + isolated re-run. CI on `main` has been red for this reason on every run today. Repairing that is out of scope for this PR; flagging here so reviewers aren't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)