### PR TITLE
chore(ci): env-file fix + runner-fleet skill + Node 24 force flag

### DIFF
--- a/.claude/skills/runner-fleet/SKILL.md
+++ b/.claude/skills/runner-fleet/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: runner-fleet
+description: Register a NEW repository against Preston's existing fleet of self-hosted GitHub Actions runners (heimdall on Synology, Alienwarerig on Win10+WSL, optional shadowsong-wsl-local). Each runner serves multiple repos in parallel via separate registrations. Use when starting a NEW repo that should share these runners, or when adding a 4th+ runner host to the fleet. NOT for first-time runner setup on a brand-new machine (that's `setup-wsl-runner`).
+---
+
+# Runner-fleet onboarding
+
+Preston runs a small fleet of self-hosted GitHub Actions runners shared across his personal repos. Each repo gets its own runner registration on each host. A single host CAN host multiple registrations side-by-side (the Synology already runs `scrum-monsters` and `hiveforge-sh` as siblings).
+
+## The fleet (as of 2026-05-15)
+
+| Host | Where | Strength | Weakness |
+|---|---|---|---|
+| `heimdall` | Synology NAS at `192.168.0.26:88` (SSH `prestonf`) | Always-on systemd service | Read-only NVMe cache over HDD - IO-bound, load 5+ |
+| `Alienwarerig` | Win10 + WSL Ubuntu at `192.168.0.245` (SSH `xavie`) | Native SSD, fastest | Depends on `WSL-Wake-Ubuntu` scheduled task |
+| `shadowsong-wsl-local` | Preston's daily-driver, WSL | Available during dev | On-demand only, never autostarted |
+
+All advertise labels `self-hosted, Linux, X64`. UIDs differ (`1030:100` on heimdall, `1000:1000` on WSL hosts) - workflows must be runner-agnostic via the chown-back pattern, NOT hardcoded `--user` flags.
+
+## Inputs from the user
+
+1. Repo full name (e.g. `xavisavvy/new-app`)
+2. Which hosts to register on - default: heimdall + Alienwarerig
+3. Does the repo's CI use Docker container actions? If yes, pre-job hook is mandatory.
+
+## Per-host registration
+
+Install-dir convention: `<runner-root>/<repo-name>` (or `<repo-name>-local` for shadowsong). On WSL hosts inside the distro at `/home/<user>/actions-runner/<repo-name>/`. Never on `/mnt/c/...`.
+
+### 1. Download runner (use same VERSION as existing)
+
+```bash
+ssh heimdall 'ls -1 /volume1/actions-runner/scrum-monsters/*.tar.gz | head -1'
+# then on each host in new install dir:
+VERSION=2.330.0
+curl -fsSL -o actions-runner.tar.gz \
+  https://github.com/actions/runner/releases/download/v$VERSION/actions-runner-linux-x64-$VERSION.tar.gz
+tar xzf actions-runner.tar.gz
+```
+
+### 2. Token (user-only, interactive)
+
+`https://github.com/<owner>/<repo>/settings/actions/runners/new` - Linux + x64. Copy ONLY the token. NEVER write to a file.
+
+### 3. Register
+
+```bash
+cd <install-dir>
+./config.sh --unattended \
+  --url https://github.com/<owner>/<repo> \
+  --token <TOKEN> \
+  --name <host-runner-name> \
+  --labels "self-hosted,Linux,X64" \
+  --work "_work" --replace
+```
+
+**CRITICAL: do NOT add custom labels.** Default labels keep the fleet fungible.
+
+### 4. .env + pre-job hook (only if repo uses Docker container actions)
+
+```bash
+INSTALL_DIR=<install-dir>
+cat >> $INSTALL_DIR/.env <<EOF
+RUNNER_UID=$(id -u)
+RUNNER_GID=$(id -g)
+ACTIONS_RUNNER_HOOK_JOB_STARTED=$INSTALL_DIR/runner-hooks/pre-job.sh
+EOF
+mkdir -p $INSTALL_DIR/runner-hooks
+cat > $INSTALL_DIR/runner-hooks/pre-job.sh <<'HOOK'
+#!/usr/bin/env bash
+set +e
+LOG="$(dirname "$(readlink -f "$0")")/pre-job.log"
+exec >> "$LOG" 2>&1
+WORK_DIR="$(dirname "$(readlink -f "$0")")/../_work"
+WORK_DIR="$(realpath "$WORK_DIR" 2>/dev/null)"
+[ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ] || exit 0
+DOCKER="$(command -v docker)"
+[ -z "$DOCKER" ] && [ -x /usr/local/bin/docker ] && DOCKER=/usr/local/bin/docker
+[ -z "$DOCKER" ] && exit 0
+"$DOCKER" run --rm -v "$WORK_DIR:/work" alpine chmod -R 777 /work
+exit 0
+HOOK
+chmod +x $INSTALL_DIR/runner-hooks/pre-job.sh
+```
+
+Why: container workflows run as root, leak root-owned files the runner user can't chmod. Docker daemon runs as root - we use Docker to chmod, sidestepping the issue. Hook runs before EVERY job including after cancellations.
+
+### 5. Install service (heimdall, Alienwarerig only)
+
+```bash
+cd <install-dir> && sudo ./svc.sh install && sudo ./svc.sh start && sudo ./svc.sh status
+```
+
+heimdall's `svc.sh` has no `restart` - use `stop && start`. Shadowsong NEVER installs as service; use `scripts/runner/local-runner.sh` for on-demand.
+
+### 6. Verify
+
+```bash
+gh api repos/<owner>/<repo>/actions/runners --jq '.runners[] | {name, status, busy}'
+```
+
+## Companion artifacts to copy into new repo
+
+1. `.claude/skills/local-runner/SKILL.md` + `scripts/runner/local-runner.sh` + `scripts/runner/local-runner.cmd` - adjust `RUNNER_DIR`/`REPO_URL`/`RUNNER_NAME_DEFAULT` inside the `.sh`.
+2. `.github/workflows/cleanup-pr-caches.yml` - drop-in copy.
+3. `.gitignore` exception:
+   ```
+   .claude/*
+   !.claude/skills/
+   ```
+4. `.gitattributes`: `*.sh text eol=lf`
+5. Container workflow pattern:
+   - First step: `chmod -R o+rwX /__w /github/home 2>/dev/null || true`
+   - Last step `if: always()`: chown back to `${RUNNER_UID:-0}:${RUNNER_GID:-0}`
+   - DO NOT hardcode `--user 1030:100`
+6. Optional: typecheck pre-check job that heavy container jobs `needs:` on.
+
+## Decommissioning
+
+```bash
+ssh <host> 'cd <install-dir> && sudo ./svc.sh stop && sudo ./svc.sh uninstall'
+# get removal token from GitHub UI
+./config.sh remove --unattended --token <REMOVAL_TOKEN>
+rm -rf <install-dir>
+```
+
+## What NOT to do
+
+- Don't share `_work` across registrations
+- Don't reuse a single registration across repos (per-repo scope)
+- Don't add custom labels (breaks job distribution)
+- Don't put `_work` on `/mnt/c/...` (10x slower)
+- Don't install Docker Desktop on WSL hosts
+- Don't skip the pre-job hook if CI uses container jobs
+
+## After onboarding
+
+Write a brief reference memory in the new repo's `.claude/projects/.../memory/` and update each runner-host's `~/.claude/CLAUDE.md` to mention the new repo.

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -18,6 +18,7 @@ permissions:
   pull-requests: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24"
 
 jobs:

--- a/.github/workflows/api-contracts.yml
+++ b/.github/workflows/api-contracts.yml
@@ -18,6 +18,9 @@ on:
       - 'shared/**'
       - 'specs/**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   validate-specs:
     name: Validate API Specs

--- a/.github/workflows/auto-rollback-monitor.yml
+++ b/.github/workflows/auto-rollback-monitor.yml
@@ -10,6 +10,7 @@ permissions:
   actions: write  # For workflow dispatch
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   ARGOCD_SERVER: argocd.local
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24"
 
 jobs:

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -21,6 +21,9 @@ concurrency:
   group: cleanup-cache-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   cleanup:
     name: Delete caches for PR #${{ github.event.pull_request.number }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,6 +10,9 @@ permissions:
   actions: write
   packages: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   cleanup-runs:
     name: Clean Old Workflow Runs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   auto-merge:
     name: Auto-Merge Dependabot PRs

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -19,6 +19,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REMOTE_HOST: "34.199.135.244"
   REMOTE_USER: "ubuntu"
   REMOTE_DIR: "/opt/scrummonsters"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24"
 
 jobs:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   label:
     name: Auto-label PRs

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: '24'
   K6_VERSION: 'v0.52.0'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   pr-title:
     name: Validate PR Title

--- a/.github/workflows/provision-vps-secrets.yml
+++ b/.github/workflows/provision-vps-secrets.yml
@@ -15,6 +15,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   provision:
     name: Append NPM admin creds to VPS .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -36,6 +36,7 @@ permissions:
   contents: read   # Default: least privilege
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   ARGOCD_SERVER: argocd.local
 
 jobs:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   gitleaks:
     name: Secret Detection

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   stale:
     name: Mark Stale

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -18,6 +18,7 @@ permissions:
   pull-requests: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24"
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "validate:specs": "npm run lint:specs && npm run generate:api-types",
     "validate:api-spec": "npm run lint:api-spec && npm run generate:api-types",
     "dev": "cross-env NODE_ENV=development tsx --env-file=.env server/index.ts",
+    "dev:ci": "cross-env NODE_ENV=development tsx server/index.ts",
     "dev:watch": "cross-env NODE_ENV=development tsx --watch --env-file=.env server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "cross-env NODE_ENV=production node dist/index.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,7 +58,11 @@ export default defineConfig({
   webServer: process.env.BASE_URL
     ? undefined
     : {
-        command: "npm run dev",
+        // Under CI there is no .env file in the fresh workspace; `npm run dev`
+        // uses `tsx --env-file=.env` which exits 9 ("file not found"). Use
+        // dev:ci variant that omits the flag. Local dev keeps the flag for
+        // automatic .env loading.
+        command: process.env.CI ? "npm run dev:ci" : "npm run dev",
         url: "http://localhost:5000",
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,


### PR DESCRIPTION
## Summary
Three small fixes bundled (Phase 2 of expert-council recommended plan):

### 1. Visual-regression `.env` fix (B3)
`npm run dev` uses \`tsx --env-file=.env\`. CI has no `.env`, so the dev server exits 9 ("file not found"), breaking Playwright webServer. Adds `dev:ci` variant in package.json and conditional in playwright.config.ts (`process.env.CI ? "npm run dev:ci" : "npm run dev"`). Local DX unchanged; CI works.

### 2. `runner-fleet` skill
Companion to existing `setup-wsl-runner` (first-time machine setup). Covers per-repo registration on the shared fleet (heimdall + Alienwarerig + shadowsong-wsl-local), pre-job hook deploy, companion artifacts to copy, decommissioning. Lets future repos plug into the fleet without re-deriving the patterns.

### 3. Node 24 forced runtime
GitHub deprecates Node 20 actions on 2026-06-02. Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at workflow level across all 20 workflows so pinned action versions (actions/checkout@v4, gitleaks@v2, etc.) keep working through the transition. No action version bumps in this PR — separate cleanup later.

## Test plan
- [x] `npx vitest run` (full suite, 736 tests pass)
- [ ] CI green
- [ ] Visual-regression no longer hits webServer exit 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)