### PR TITLE
fix(security): P1 hardening — payload validation (M-2), rate limiting (H-6), lobby cap + reaper (H-5), score validation (M-1)

### DIFF
--- a/server/domains/SessionManager.test.ts
+++ b/server/domains/SessionManager.test.ts
@@ -53,6 +53,34 @@ describe('SessionManager - Lobby Lifecycle', () => {
       }
     });
 
+    it('reaps only lobbies idle beyond the TTL, cleaning up state (Security: H-5)', () => {
+      const sm = new SessionManager({ eventBus: new ScopedEventBus() });
+      const lobby = sm.createLobby('A', 'L1');
+      const hostId = lobby.players[0].id;
+      const start = Date.now();
+      const TTL = 30 * 60 * 1000;
+
+      // Within TTL → not reaped.
+      expect(sm.reapIdleLobbies(start + 60_000)).toEqual([]);
+      expect(sm.getLobbyCount()).toBe(1);
+
+      // Beyond TTL → reaped and fully cleaned up.
+      const reaped = sm.reapIdleLobbies(start + TTL + 1000);
+      expect(reaped).toContain(lobby.id);
+      expect(sm.getLobbyCount()).toBe(0);
+      expect(sm.getPlayerLobby(hostId)).toBeNull();
+    });
+
+    it('recordLobbyActivity keeps a lobby within the idle window', () => {
+      const sm = new SessionManager({ eventBus: new ScopedEventBus() });
+      const lobby = sm.createLobby('A', 'L1');
+      const t = Date.now();
+      sm.recordLobbyActivity(lobby.id);
+      // Checking just under one TTL after the activity stamp must not reap it.
+      expect(sm.reapIdleLobbies(t + 30 * 60 * 1000 - 5000)).toEqual([]);
+      expect(sm.getLobbyCount()).toBe(1);
+    });
+
     it('should initialize playerCombatStates for host', () => {
       const lobby = sessionManager.createLobby('Host Player', 'Test Lobby');
       const hostId = lobby.players[0].id;

--- a/server/domains/SessionManager.test.ts
+++ b/server/domains/SessionManager.test.ts
@@ -36,6 +36,23 @@ describe('SessionManager - Lobby Lifecycle', () => {
       expect(lobby.completedTickets).toEqual([]);
     });
 
+    it('rejects creation past MAX_LOBBIES capacity (Security: H-5)', () => {
+      const prev = process.env.MAX_LOBBIES;
+      process.env.MAX_LOBBIES = '2';
+      try {
+        const sm = new SessionManager({ eventBus: new ScopedEventBus() });
+        sm.createLobby('A', 'L1');
+        sm.createLobby('B', 'L2');
+        expect(sm.getLobbyCount()).toBe(2);
+        // Third creation must be rejected, not silently grow the map.
+        expect(() => sm.createLobby('C', 'L3')).toThrow(/capacity/i);
+        expect(sm.getLobbyCount()).toBe(2);
+      } finally {
+        if (prev === undefined) delete process.env.MAX_LOBBIES;
+        else process.env.MAX_LOBBIES = prev;
+      }
+    });
+
     it('should initialize playerCombatStates for host', () => {
       const lobby = sessionManager.createLobby('Host Player', 'Test Lobby');
       const hostId = lobby.players[0].id;

--- a/server/domains/SessionManager.ts
+++ b/server/domains/SessionManager.ts
@@ -27,6 +27,7 @@ import {
   AvatarClass,
 } from '../../shared/gameEvents';
 import {
+  SessionError,
   LobbyNotFoundError,
   PlayerNotFoundError,
   PlayerNotHostError,
@@ -78,6 +79,10 @@ export class SessionManager {
   private playerActivity = new Map<string, number>();
 
   // Constants
+  // Hard ceiling on concurrent lobbies. Bounds memory against create_lobby
+  // flooding (no per-socket rate limit exists on the WS layer yet — H-6).
+  // Override via MAX_LOBBIES env for larger deployments. (Security: H-5)
+  private readonly MAX_LOBBIES = Number(process.env.MAX_LOBBIES) || 500;
   private readonly DISCONNECT_GRACE_PERIOD = 10 * 60 * 1000; // 10 minutes
   // Aligned with DISCONNECT_GRACE_PERIOD so a player in the grace window cannot hold a structurally expired token. Trade-off: wider replay window — acceptable given HMAC signature + per-player binding. (Phase 41)
   private readonly TOKEN_EXPIRY_TIME = 10 * 60 * 1000; // 10 minutes
@@ -108,6 +113,17 @@ export class SessionManager {
     lobbyName: string,
     options?: CreateLobbyOptions
   ): Lobby {
+    // Reject when at capacity so a flood of create_lobby calls cannot exhaust
+    // server memory. The create_lobby handler catches SessionError and relays
+    // a game_error to the client. (Security: H-5)
+    if (this.lobbies.size >= this.MAX_LOBBIES) {
+      gameLogger.warn(
+        { lobbyCount: this.lobbies.size, max: this.MAX_LOBBIES },
+        'Lobby capacity reached; rejecting create_lobby'
+      );
+      throw new SessionError('LOBBY_CAPACITY_REACHED', 'Server is at capacity. Please try again shortly.');
+    }
+
     // Generate lobby ID
     const lobbyId =
       options?.customLobbyId ||

--- a/server/domains/SessionManager.ts
+++ b/server/domains/SessionManager.ts
@@ -77,12 +77,20 @@ export class SessionManager {
   private disconnectedPlayers = new Map<string, DisconnectedPlayer>();
   private reconnectTokens = new Map<string, ReconnectToken>();
   private playerActivity = new Map<string, number>();
+  // Last time any client event touched a lobby. Stamped on create + on every
+  // validated socket event (incl. the 25s client_heartbeat), so a lobby with
+  // any connected client stays fresh. Drives the idle-lobby reaper. (H-5)
+  private lobbyActivity = new Map<string, number>();
 
   // Constants
   // Hard ceiling on concurrent lobbies. Bounds memory against create_lobby
   // flooding (no per-socket rate limit exists on the WS layer yet — H-6).
   // Override via MAX_LOBBIES env for larger deployments. (Security: H-5)
   private readonly MAX_LOBBIES = Number(process.env.MAX_LOBBIES) || 500;
+  // A lobby with no client event (not even a heartbeat) for this long has no
+  // connected clients and is reaped to bound memory. Connected clients
+  // heartbeat every ~25s, so active lobbies never hit this. (Security: H-5)
+  private readonly LOBBY_IDLE_TTL = 30 * 60 * 1000; // 30 minutes
   private readonly DISCONNECT_GRACE_PERIOD = 10 * 60 * 1000; // 10 minutes
   // Aligned with DISCONNECT_GRACE_PERIOD so a player in the grace window cannot hold a structurally expired token. Trade-off: wider replay window — acceptable given HMAC signature + per-player binding. (Phase 41)
   private readonly TOKEN_EXPIRY_TIME = 10 * 60 * 1000; // 10 minutes
@@ -208,6 +216,7 @@ export class SessionManager {
     this.lobbies.set(lobbyId, lobby);
     this.playerToLobby.set(hostId, lobbyId);
     this.playerActivity.set(hostId, Date.now());
+    this.lobbyActivity.set(lobbyId, Date.now());
 
     // Emit domain event. team + avatar must be included so other clients'
     // incremental session:player_joined handler can place this player on the
@@ -376,6 +385,54 @@ export class SessionManager {
   }
 
   /**
+   * Records that a lobby received client activity (called from the socket
+   * gateway on every validated event). Keeps the idle-lobby reaper from
+   * reaping lobbies that still have connected clients. (Security: H-5)
+   */
+  recordLobbyActivity(lobbyId: string): void {
+    if (this.lobbies.has(lobbyId)) {
+      this.lobbyActivity.set(lobbyId, Date.now());
+    }
+  }
+
+  /**
+   * Reaps lobbies that have received no client event (not even a heartbeat)
+   * for LOBBY_IDLE_TTL — i.e. abandoned/orphaned lobbies with no connected
+   * clients. Returns the reaped lobby IDs. Bounds memory together with the
+   * MAX_LOBBIES cap. (Security: H-5)
+   */
+  reapIdleLobbies(now: number = Date.now()): string[] {
+    const reaped: string[] = [];
+    // Snapshot ids: removePlayer mutates this.lobbies during the sweep.
+    for (const lobbyId of [...this.lobbies.keys()]) {
+      const last = this.lobbyActivity.get(lobbyId) ?? 0;
+      if (now - last <= this.LOBBY_IDLE_TTL) continue;
+
+      const lobby = this.lobbies.get(lobbyId);
+      if (!lobby) continue;
+
+      // Remove every player; the final removal empties the lobby and triggers
+      // the existing destroy path (lobby_destroyed + event-scope cleanup).
+      for (const playerId of lobby.players.map((p) => p.id)) {
+        this.removePlayer(playerId);
+      }
+      // Belt-and-suspenders: ensure the lobby and its activity entry are gone
+      // even if it had zero players when reaped.
+      if (this.lobbies.delete(lobbyId)) {
+        this.eventBus.emit('session:lobby_destroyed', { lobbyId });
+        this.eventBus.cleanupScope(lobbyId);
+      }
+      this.lobbyActivity.delete(lobbyId);
+      reaped.push(lobbyId);
+    }
+
+    if (reaped.length > 0) {
+      gameLogger.info({ count: reaped.length, lobbyIds: reaped }, 'Reaped idle lobbies');
+    }
+    return reaped;
+  }
+
+  /**
    * Gets the lobby a player is currently in
    */
   getPlayerLobby(playerId: string): Lobby | null {
@@ -424,6 +481,7 @@ export class SessionManager {
     // Check if lobby is empty
     if (lobby.players.length === 0) {
       this.lobbies.delete(lobbyId);
+      this.lobbyActivity.delete(lobbyId);
       this.eventBus.emit('session:lobby_destroyed', {
         lobbyId,
       });

--- a/server/gameState.ts
+++ b/server/gameState.ts
@@ -1,4 +1,4 @@
-import { Lobby, Player, Boss, JiraTicket, CompletedTicket, TeamType, AvatarClass, TeamScores, TeamConsensus, TimerSettings, JiraSettings, TimerState, EstimationSettings, ReconnectToken, DisconnectedPlayer, LobbySync, ReconnectResponse, RingAttack, RingAttackProjectile } from '../shared/gameEvents.js';
+import { Lobby, Player, Boss, JiraTicket, CompletedTicket, TeamType, AvatarClass, TeamScores, TeamConsensus, TimerSettings, JiraSettings, TimerState, EstimationSettings, ReconnectToken, DisconnectedPlayer, LobbySync, ReconnectResponse, RingAttack, RingAttackProjectile, isValidEstimationScore } from '../shared/gameEvents.js';
 import { TeamStatsManager } from './teamStatsManager.js';
 import { createHmac, randomBytes, randomInt } from 'crypto';
 import { cacheLobby, deleteCachedLobby, deletePlayerSession, isRedisConnected } from './redis.js';
@@ -1329,6 +1329,14 @@ class GameStateManager {
 
     const player = lobby.players.find(p => p.id === playerId);
     if (!player || player.team === 'spectators') return null;
+
+    // Reject values outside the configured estimation scale (abstain '?' is
+    // always allowed). Without this, a client could submit arbitrary/huge/NaN
+    // values that corrupt consensus math and the reveal grid. (Security: M-1)
+    if (!isValidEstimationScore(score, lobby.estimationSettings)) {
+      gameLogger.warn({ playerId, lobbyId: lobby.id, score }, 'Rejected out-of-scale submit_score');
+      return null;
+    }
 
     player.currentScore = score;
     player.hasSubmittedScore = true;

--- a/server/middleware/socketRateLimiter.test.ts
+++ b/server/middleware/socketRateLimiter.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucket, SocketRateLimiter } from './socketRateLimiter';
+
+describe('TokenBucket (Security: H-6)', () => {
+  it('allows up to capacity in a burst, then denies', () => {
+    const b = new TokenBucket(3, 1, 0);
+    expect(b.tryRemove(0)).toBe(true);
+    expect(b.tryRemove(0)).toBe(true);
+    expect(b.tryRemove(0)).toBe(true);
+    expect(b.tryRemove(0)).toBe(false); // empty
+  });
+
+  it('refills over time at refillPerSec', () => {
+    const b = new TokenBucket(2, 1, 0); // 1 token/sec
+    b.tryRemove(0);
+    b.tryRemove(0);
+    expect(b.tryRemove(0)).toBe(false);
+    expect(b.tryRemove(1000)).toBe(true);  // +1 token after 1s
+    expect(b.tryRemove(1000)).toBe(false);
+  });
+
+  it('never exceeds capacity when idle a long time', () => {
+    const b = new TokenBucket(2, 1, 0);
+    // idle 1 hour, then should still only allow `capacity` in a burst
+    expect(b.tryRemove(3_600_000)).toBe(true);
+    expect(b.tryRemove(3_600_000)).toBe(true);
+    expect(b.tryRemove(3_600_000)).toBe(false);
+  });
+});
+
+describe('SocketRateLimiter (Security: H-6)', () => {
+  const limits = { create_lobby: { capacity: 2, refillPerSec: 0.1 } };
+
+  it('limits configured events per-socket', () => {
+    const rl = new SocketRateLimiter(limits);
+    expect(rl.allow('create_lobby', 0)).toBe(true);
+    expect(rl.allow('create_lobby', 0)).toBe(true);
+    expect(rl.allow('create_lobby', 0)).toBe(false); // 3rd in burst denied
+  });
+
+  it('never limits unconfigured (hot-path) events', () => {
+    const rl = new SocketRateLimiter(limits);
+    for (let i = 0; i < 1000; i++) {
+      expect(rl.allow('player_pos', 0)).toBe(true);
+    }
+  });
+
+  it('tracks buckets independently per event', () => {
+    const rl = new SocketRateLimiter({
+      a: { capacity: 1, refillPerSec: 0 },
+      b: { capacity: 1, refillPerSec: 0 },
+    });
+    expect(rl.allow('a', 0)).toBe(true);
+    expect(rl.allow('a', 0)).toBe(false);
+    expect(rl.allow('b', 0)).toBe(true); // independent of 'a'
+  });
+});

--- a/server/middleware/socketRateLimiter.ts
+++ b/server/middleware/socketRateLimiter.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-socket, per-event token-bucket rate limiting for the WebSocket layer
+ * (Security: H-6). Deliberately applied to ONLY a small set of expensive /
+ * abusable events (see RATE_LIMITS in websocket.ts) — high-frequency gameplay
+ * events (movement, charge, jump, votes, emotes) are intentionally NOT limited
+ * so real-time responsiveness is unaffected.
+ */
+
+export interface RateLimitConfig {
+  /** Maximum burst size (tokens available when full). */
+  capacity: number;
+  /** Sustained refill rate in tokens per second. */
+  refillPerSec: number;
+}
+
+/**
+ * A classic token bucket. `tryRemove()` returns true if a token was available
+ * (request allowed) or false if the bucket is empty (request denied). Time is
+ * injectable for deterministic tests.
+ */
+export class TokenBucket {
+  private tokens: number;
+  private lastRefill: number;
+
+  constructor(
+    private readonly capacity: number,
+    private readonly refillPerSec: number,
+    now: number = Date.now(),
+  ) {
+    this.tokens = capacity;
+    this.lastRefill = now;
+  }
+
+  tryRemove(now: number = Date.now()): boolean {
+    const elapsedSec = Math.max(0, (now - this.lastRefill) / 1000);
+    this.tokens = Math.min(this.capacity, this.tokens + elapsedSec * this.refillPerSec);
+    this.lastRefill = now;
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Tracks per-event token buckets for a single socket. Buckets are created lazily
+ * the first time an event is seen. Events without a configured limit are always
+ * allowed (returns true) and never allocate a bucket.
+ */
+export class SocketRateLimiter {
+  private readonly buckets = new Map<string, TokenBucket>();
+
+  constructor(
+    private readonly limits: Readonly<Record<string, RateLimitConfig>>,
+  ) {}
+
+  /** Returns true if the event is allowed, false if it exceeds its limit. */
+  allow(event: string, now: number = Date.now()): boolean {
+    const cfg = this.limits[event];
+    if (!cfg) return true; // unlimited event
+    let bucket = this.buckets.get(event);
+    if (!bucket) {
+      bucket = new TokenBucket(cfg.capacity, cfg.refillPerSec, now);
+      this.buckets.set(event, bucket);
+    }
+    return bucket.tryRemove(now);
+  }
+}

--- a/server/websocket.ts
+++ b/server/websocket.ts
@@ -34,6 +34,25 @@ import {
   BossDamagePlayerPayloadSchema,
 } from '../shared/socket-schemas.js';
 import { redactLobbyForWire } from './events/ClientEventEmitter.js';
+import { SocketRateLimiter, type RateLimitConfig } from './middleware/socketRateLimiter.js';
+
+// Per-event WebSocket rate limits (Security: H-6). ONLY expensive / abusable
+// events are listed — high-frequency gameplay events (movement, charge, jump,
+// votes, emotes, attacks) are intentionally omitted so real-time
+// responsiveness is never throttled. Limits are generous for legitimate use
+// and only bite on floods. Skipped entirely under NODE_ENV=test.
+const WS_RATE_LIMITS: Readonly<Record<string, RateLimitConfig>> = {
+  create_lobby: { capacity: 5, refillPerSec: 0.2 },        // burst 5, ~1 / 5s sustained
+  join_lobby: { capacity: 10, refillPerSec: 1 },
+  add_tickets: { capacity: 30, refillPerSec: 3 },
+  remove_ticket: { capacity: 30, refillPerSec: 3 },
+  update_lobby_name: { capacity: 20, refillPerSec: 2 },
+  reconnect_with_token: { capacity: 10, refillPerSec: 1 },
+  update_jira_settings: { capacity: 20, refillPerSec: 2 },
+  update_timer_settings: { capacity: 20, refillPerSec: 2 },
+  update_estimation_settings: { capacity: 20, refillPerSec: 2 },
+  youtube_play: { capacity: 20, refillPerSec: 2 },
+};
 import { updateWebsocketMetrics } from "./metrics.js";
 import { ITEM_DEFINITIONS, type ItemType } from '../shared/itemTypes.js';
 
@@ -287,6 +306,19 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     }
   }, 30000);
 
+  // Idle-lobby reaper (Security: H-5). Removes lobbies that have received no
+  // client event for LOBBY_IDLE_TTL — i.e. abandoned/orphaned lobbies with no
+  // connected clients. Connected clients heartbeat every ~25s (stamping
+  // activity via the gateway), so active lobbies are never reaped. Bounds
+  // memory together with the MAX_LOBBIES cap.
+  const idleLobbyReaperInterval = setInterval(() => {
+    try {
+      sessionManager.reapIdleLobbies();
+    } catch (err) {
+      socketLogger.error({ err }, 'idleLobbyReaper failed');
+    }
+  }, 5 * 60 * 1000);
+
   // Periodic recompute of the labeled websocketConnections gauge.
   // Many code paths mutate socket.data.lobbyId / socket.data.userId
   // (create_lobby, join_lobby, leave_lobby, reconnect, etc.) without
@@ -335,16 +367,27 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // Update Prometheus WebSocket connection gauge
     updateWebsocketMetrics(io);
 
+    // Per-socket rate limiter for expensive/abusable events (Security: H-6).
+    // Disabled under test to keep unit/integration tests deterministic.
+    const isTest = process.env.NODE_ENV === 'test';
+    const rateLimiter = new SocketRateLimiter(WS_RATE_LIMITS);
+
     // Central validation gateway (Security: M-2). Every client event is
-    // validated against its schema in ClientEventSchemas before the handler
-    // runs; malformed/out-of-shape payloads are rejected with a game_error and
-    // never reach game state. Replaces ~50 hand-rolled (mostly absent) checks.
-    // `disconnect` is a lifecycle event and stays on raw socket.on below.
+    // rate-checked (H-6), then validated against its schema in
+    // ClientEventSchemas before the handler runs; malformed/out-of-shape
+    // payloads are rejected with a game_error and never reach game state.
+    // Replaces ~50 hand-rolled (mostly absent) checks. `disconnect` is a
+    // lifecycle event and stays on raw socket.on below.
     const on = <E extends keyof typeof ClientEventSchemas>(
       event: E,
       handler: (data: z.infer<(typeof ClientEventSchemas)[E]>) => void,
     ): void => {
       socket.on(event as keyof ClientToServerEvents, ((raw: unknown) => {
+        if (!isTest && !rateLimiter.allow(event as string)) {
+          socketLogger.warn({ event, socketId: socket.id }, 'Rate limit exceeded for socket event');
+          socket.emit('game_error', { message: 'Rate limit exceeded. Please slow down.' });
+          return;
+        }
         const result = validatePayload(ClientEventSchemas[event] as z.ZodType<unknown>, raw);
         if (!result.success) {
           socketLogger.warn(
@@ -353,6 +396,11 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
           );
           socket.emit('game_error', { message: `Invalid ${String(event)} payload` });
           return;
+        }
+        // Stamp lobby activity so the idle-lobby reaper (H-5) never reaps a
+        // lobby that is still receiving client events.
+        if (socket.data.lobbyId) {
+          sessionManager.recordLobbyActivity(socket.data.lobbyId);
         }
         handler(result.data as z.infer<(typeof ClientEventSchemas)[E]>);
       }) as never);
@@ -2027,6 +2075,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       clearInterval(websocketMetricsInterval);
       clearInterval(revivalWatchdogInterval);
       clearInterval(sessionDisconnectSweeperInterval);
+      clearInterval(idleLobbyReaperInterval);
       eventBus.off('session:lobby_destroyed', lobbyDestroyedHandler);
       pendingPositionUpdates.clear();
     }

--- a/server/websocket.ts
+++ b/server/websocket.ts
@@ -26,8 +26,10 @@ import {
   PlayerNotHostError,
   SessionError,
 } from './domains/index.js';
+import type { z } from 'zod';
 import {
   validatePayload,
+  ClientEventSchemas,
   ToggleReadyPayloadSchema,
   BossDamagePlayerPayloadSchema,
 } from '../shared/socket-schemas.js';
@@ -333,7 +335,30 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // Update Prometheus WebSocket connection gauge
     updateWebsocketMetrics(io);
 
-    socket.on('create_lobby', ({ lobbyName, hostName, initialSettings }) => {
+    // Central validation gateway (Security: M-2). Every client event is
+    // validated against its schema in ClientEventSchemas before the handler
+    // runs; malformed/out-of-shape payloads are rejected with a game_error and
+    // never reach game state. Replaces ~50 hand-rolled (mostly absent) checks.
+    // `disconnect` is a lifecycle event and stays on raw socket.on below.
+    const on = <E extends keyof typeof ClientEventSchemas>(
+      event: E,
+      handler: (data: z.infer<(typeof ClientEventSchemas)[E]>) => void,
+    ): void => {
+      socket.on(event as keyof ClientToServerEvents, ((raw: unknown) => {
+        const result = validatePayload(ClientEventSchemas[event] as z.ZodType<unknown>, raw);
+        if (!result.success) {
+          socketLogger.warn(
+            { event, socketId: socket.id, issues: result.error.issues.slice(0, 3) },
+            'Rejected invalid socket payload',
+          );
+          socket.emit('game_error', { message: `Invalid ${String(event)} payload` });
+          return;
+        }
+        handler(result.data as z.infer<(typeof ClientEventSchemas)[E]>);
+      }) as never);
+    };
+
+    on('create_lobby', ({ lobbyName, hostName, initialSettings }) => {
       try {
         const lobby = sessionManager.createLobby(hostName, lobbyName, initialSettings);
 
@@ -416,7 +441,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('join_lobby', ({ lobbyId, playerName }) => {
+    on('join_lobby', ({ lobbyId, playerName }) => {
       try {
         const { lobby, player } = sessionManager.joinLobby(lobbyId, playerName);
 
@@ -530,7 +555,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('select_avatar', ({ avatarClass }) => {
+    on('select_avatar', ({ avatarClass }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -563,7 +588,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       emitFineGrained(lobby.id, 'session:avatar_selected', { playerId, avatar: avatarClass });
     });
 
-    socket.on('assign_team', ({ playerId: targetPlayerId, team }) => {
+    on('assign_team', ({ playerId: targetPlayerId, team }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -596,7 +621,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('change_own_team', ({ team }) => {
+    on('change_own_team', ({ team }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -647,7 +672,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('add_tickets', ({ tickets }) => {
+    on('add_tickets', ({ tickets }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -665,7 +690,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.info({ playerId, ticketCount: tickets.length, lobbyId: lobby.id }, 'Host added tickets');
     });
 
-    socket.on('remove_ticket', ({ ticketId }) => {
+    on('remove_ticket', ({ ticketId }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -684,7 +709,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Explicit leave lobby (user clicked back to menu)
-    socket.on('leave_lobby', () => {
+    on('leave_lobby', () => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       if (!playerId || !lobbyId) return;
@@ -709,7 +734,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Update lobby name (host only)
-    socket.on('update_lobby_name', ({ name }) => {
+    on('update_lobby_name', ({ name }) => {
       socketLogger.debug({ name }, 'update_lobby_name received');
 
       const playerId = socket.data.playerId;
@@ -743,7 +768,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Lobby movement events for 2D sidescroller playground
-    socket.on('lobby_player_pos', ({ x, y, direction }) => {
+    on('lobby_player_pos', ({ x, y, direction }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       if (!playerId || !lobbyId) return;
@@ -764,7 +789,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       });
     });
 
-    socket.on('lobby_player_jump', ({ isJumping }) => {
+    on('lobby_player_jump', ({ isJumping }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       if (!playerId || !lobbyId) return;
@@ -783,7 +808,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       });
     });
 
-    socket.on('player_charge', ({ isCharging, chargePower }: { isCharging: boolean; chargePower?: number }) => {
+    on('player_charge', ({ isCharging, chargePower }: { isCharging: boolean; chargePower?: number }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       
@@ -802,7 +827,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       });
     });
 
-    socket.on('lobby_emote', ({ message, x, y }) => {
+    on('lobby_emote', ({ message, x, y }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       if (!playerId || !lobbyId) return;
@@ -831,7 +856,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.debug({ playerId, lobbyId, message: message.trim() }, 'Player emoted in lobby');
     });
 
-    socket.on('toggle_ready', (data) => {
+    on('toggle_ready', (data) => {
       const result = validatePayload(ToggleReadyPayloadSchema, data);
       if (!result.success) {
         socket.emit('game_error', { message: 'Invalid toggle_ready payload' });
@@ -863,7 +888,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Handle battle emotes
-    socket.on('battle_emote', ({ message, x, y }) => {
+    on('battle_emote', ({ message, x, y }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       if (!playerId || !lobbyId) return;
@@ -892,7 +917,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.debug({ playerId, lobbyId, message: message.trim() }, 'Player battle emoted');
     });
 
-    socket.on('start_battle', () => {
+    on('start_battle', () => {
       const playerId = socket.data.playerId;
       socketLogger.debug({ socketId: socket.id, playerId }, 'start_battle received');
 
@@ -952,7 +977,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('submit_score', ({ score }) => {
+    on('submit_score', ({ score }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1036,7 +1061,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('update_discussion_vote', ({ score }) => {
+    on('update_discussion_vote', ({ score }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1072,7 +1097,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('attack_boss', ({ damage }) => {
+    on('attack_boss', ({ damage }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1118,7 +1143,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // It is therefore only valid for a player to report damage to ITSELF.
     // Without the self-target guard, any client could down (or, via a negative
     // value, heal) any player in any lobby and force game_over. (Security: H-1)
-    socket.on('boss_damage_player', (data) => {
+    on('boss_damage_player', (data) => {
       const attackerId = socket.data.playerId;
       if (!attackerId) return;
 
@@ -1150,7 +1175,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Player projectile broadcasting for multiplayer visibility
-    socket.on('player_projectile', ({ startX, startY, targetX, targetY, emoji, targetPlayerId }) => {
+    on('player_projectile', ({ startX, startY, targetX, targetY, emoji, targetPlayerId }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1177,7 +1202,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.debug({ playerName: player.name, emoji, targetType: targetPlayerId ? 'player' : 'boss' }, 'Broadcasting projectile');
     });
 
-    socket.on('proceed_next_level', () => {
+    on('proceed_next_level', () => {
       try {
         const playerId = socket.data.playerId;
         const lobbyId = socket.data.lobbyId;
@@ -1250,7 +1275,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('abandon_quest', () => {
+    on('abandon_quest', () => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1268,7 +1293,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('restart_game', () => {
+    on('restart_game', () => {
       socketLogger.debug('Server received restart_game event');
       const playerId = socket.data.playerId;
       if (!playerId) {
@@ -1289,7 +1314,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('return_to_lobby', () => {
+    on('return_to_lobby', () => {
       socketLogger.debug('Server received return_to_lobby event');
       const playerId = socket.data.playerId;
       if (!playerId) {
@@ -1312,7 +1337,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('force_reveal', () => {
+    on('force_reveal', () => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1361,7 +1386,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('youtube_play', ({ videoId, url }) => {
+    on('youtube_play', ({ videoId, url }) => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       
@@ -1379,7 +1404,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.debug({ playerId, url }, 'Host started YouTube music');
     });
 
-    socket.on('youtube_stop', () => {
+    on('youtube_stop', () => {
       const playerId = socket.data.playerId;
       const lobbyId = socket.data.lobbyId;
       
@@ -1397,7 +1422,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       socketLogger.debug({ playerId }, 'Host stopped YouTube music');
     });
 
-    socket.on('advancePhaseNow', () => {
+    on('advancePhaseNow', () => {
       try {
         // Identity MUST come from the authenticated socket, never the payload.
         // The previous implementation compared two attacker-supplied values
@@ -1439,7 +1464,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('forceVotingProgression', ({ lobbyId }) => {
+    on('forceVotingProgression', ({ lobbyId }) => {
       try {
         const playerId = socket.data.playerId;
         if (!playerId) {
@@ -1492,7 +1517,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Position sync for combat - batched for performance
-    socket.on('player_pos', ({ x, y }: { x: number; y: number }) => {
+    on('player_pos', ({ x, y }: { x: number; y: number }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1504,7 +1529,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Player vs player combat
-    socket.on('attack_player', ({ targetId, damage }: { targetId: string; damage: number }) => {
+    on('attack_player', ({ targetId, damage }: { targetId: string; damage: number }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1529,7 +1554,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Party healing (priest special ability)
-    socket.on('heal_party', () => {
+    on('heal_party', () => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1547,7 +1572,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // Phase 45-04: legacy revive_progress/revive_cancelled socket emits
     // replaced by eventBus.emit('combat:revival_started' / '...:cancelled')
     // so the bridge surfaces them to the new client handlers.
-    socket.on('revive_start', ({ targetId }: { targetId: string }) => {
+    on('revive_start', ({ targetId }: { targetId: string }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1565,7 +1590,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('revive_cancel', ({ targetId }: { targetId: string }) => {
+    on('revive_cancel', ({ targetId }: { targetId: string }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1583,7 +1608,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('revive_tick', ({ targetId }: { targetId: string }) => {
+    on('revive_tick', ({ targetId }: { targetId: string }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1604,7 +1629,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Jumping state sync
-    socket.on('player_jump', ({ isJumping }: { isJumping: boolean }) => {
+    on('player_jump', ({ isJumping }: { isJumping: boolean }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1615,7 +1640,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Timer settings update
-    socket.on('update_timer_settings', ({ timerSettings }) => {
+    on('update_timer_settings', ({ timerSettings }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1626,7 +1651,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('update_jira_settings', ({ jiraSettings }) => {
+    on('update_jira_settings', ({ jiraSettings }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1637,7 +1662,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       }
     });
 
-    socket.on('update_estimation_settings', ({ estimationSettings }) => {
+    on('update_estimation_settings', ({ estimationSettings }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1651,7 +1676,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Reconnection handler
-    socket.on('reconnect_with_token', ({ reconnectToken }) => {
+    on('reconnect_with_token', ({ reconnectToken }) => {
       try {
         const response = sessionManager.attemptPlayerReconnect(reconnectToken);
 
@@ -1744,7 +1769,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Client heartbeat to prevent infrastructure timeouts (Cloudflare/Replit ~2min idle limit)
-    socket.on('client_heartbeat', () => {
+    on('client_heartbeat', () => {
       // Simply acknowledge - the act of receiving this message resets infrastructure idle timers
       const playerId = socket.data.playerId;
       if (playerId) {
@@ -1753,7 +1778,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     });
 
     // Handle missed events request (sequence gap recovery)
-    socket.on('request_missed_events', ({ lastSeq }) => {
+    on('request_missed_events', ({ lastSeq }) => {
       const lobbyId = socket.data.lobbyId;
       if (!lobbyId) {
         socketLogger.warn('request_missed_events: No lobbyId in socket data');
@@ -1792,7 +1817,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // EstimationManager event bus.
 
     // Finalize estimate (host only during discussion)
-    socket.on('finalize_estimate', (data: { estimate: number }) => {
+    on('finalize_estimate', (data: { estimate: number }) => {
       try {
         const playerId = socket.data.playerId;
         const lobbyId = socket.data.lobbyId;
@@ -1831,7 +1856,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // routed through use_ability / heal_party.
 
     // Player uses class ability
-    socket.on('use_ability', ({ abilityId }: { abilityId: string }) => {
+    on('use_ability', ({ abilityId }: { abilityId: string }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1860,7 +1885,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
       gameLogger.debug({ playerId, abilityId }, 'Player used ability');
     });
 
-    socket.on('use_item', ({ itemType }: { itemType: string }) => {
+    on('use_item', ({ itemType }: { itemType: string }) => {
       const playerId = socket.data.playerId;
       if (!playerId) return;
 
@@ -1894,7 +1919,7 @@ export function setupWebSocket(httpServer: HTTPServer, sessionMiddleware?: Reque
     // in this file.
 
     // Attack minion (player targeting spectator minion)
-    socket.on('attack_minion', (data: { minionPlayerId: string }) => {
+    on('attack_minion', (data: { minionPlayerId: string }) => {
       try {
         const playerId = socket.data.playerId;
         const lobbyId = socket.data.lobbyId;

--- a/shared/clientEventSchemas.contract.test.ts
+++ b/shared/clientEventSchemas.contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { ClientEventSchemas, validatePayload } from './socket-schemas';
+
+/**
+ * Contract tests for the central socket validation gateway (Security: M-2).
+ * The websocket layer now validates every client event against
+ * ClientEventSchemas before the handler runs, so a schema that is stricter
+ * than the real client payload would silently break that feature. These tests
+ * lock the two failure classes that unit tests don't exercise:
+ *   1. no-arg events must accept the `undefined` Socket.IO delivers, and
+ *   2. representative real payloads must pass / malformed ones must fail.
+ */
+
+// Events the client emits with NO argument → handler receives `undefined`.
+const NO_ARG_EVENTS = [
+  'leave_lobby', 'start_battle', 'proceed_next_level', 'restart_game',
+  'abandon_quest', 'force_reveal', 'youtube_stop', 'heal_party',
+  'return_to_lobby', 'client_heartbeat',
+] as const;
+
+describe('ClientEventSchemas contract (M-2)', () => {
+  it('no-arg events accept undefined (Socket.IO no-payload emit)', () => {
+    for (const event of NO_ARG_EVENTS) {
+      const schema = ClientEventSchemas[event];
+      expect(schema, `${event} missing from registry`).toBeDefined();
+      const r = validatePayload(schema as never, undefined);
+      expect(r.success, `${event} schema must accept undefined`).toBe(true);
+    }
+  });
+
+  it('accepts representative valid payloads for key mutating events', () => {
+    const valid: Array<[keyof typeof ClientEventSchemas, unknown]> = [
+      ['create_lobby', { lobbyName: 'My Lobby', hostName: 'Alice' }],
+      ['join_lobby', { lobbyId: 'ABC123', playerName: 'Bob' }],
+      ['assign_team', { playerId: 'p1', team: 'developers' }],
+      ['change_own_team', { team: 'qa' }],
+      ['submit_score', { score: 8 }],
+      ['submit_score', { score: '?' }],
+      ['lobby_player_pos', { x: 12.5, y: 80, direction: 'left' }],
+      ['lobby_player_pos', { x: 12.5, y: 80 }], // direction optional
+    ];
+    for (const [event, payload] of valid) {
+      const r = validatePayload(ClientEventSchemas[event] as never, payload);
+      expect(r.success, `${event} should accept ${JSON.stringify(payload)}`).toBe(true);
+    }
+  });
+
+  it('rejects malformed payloads for those events', () => {
+    const invalid: Array<[keyof typeof ClientEventSchemas, unknown]> = [
+      ['create_lobby', { lobbyName: '', hostName: 'Alice' }],      // empty name
+      ['create_lobby', { hostName: 'Alice' }],                     // missing lobbyName
+      ['join_lobby', { lobbyId: 'ABC' }],                          // missing playerName
+      ['assign_team', { playerId: 'p1', team: 'ghosts' }],         // invalid team
+      ['change_own_team', {}],                                     // missing team
+      ['submit_score', { score: {} }],                             // wrong type
+      ['lobby_player_pos', { x: 'nope', y: 80 }],                  // wrong type
+    ];
+    for (const [event, payload] of invalid) {
+      const r = validatePayload(ClientEventSchemas[event] as never, payload);
+      expect(r.success, `${event} should reject ${JSON.stringify(payload)}`).toBe(false);
+    }
+  });
+});

--- a/shared/estimationScore.test.ts
+++ b/shared/estimationScore.test.ts
@@ -35,7 +35,6 @@ describe('isValidEstimationScore (Security: M-1)', () => {
 
   it('rejects non-numeric, non-"?" payloads', () => {
     for (const bad of ['XS', 'abc', '', null, undefined, {}, [], true, () => 1]) {
-      // @ts-expect-error — intentionally passing invalid types
       expect(isValidEstimationScore(bad)).toBe(false);
     }
   });

--- a/shared/estimationScore.test.ts
+++ b/shared/estimationScore.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isValidEstimationScore, ESTIMATION_SCALES } from './gameEvents';
+
+describe('isValidEstimationScore (Security: M-1)', () => {
+  it('accepts the abstain sentinel regardless of scale', () => {
+    expect(isValidEstimationScore('?')).toBe(true);
+    expect(isValidEstimationScore('?', { scaleType: 'doubling' })).toBe(true);
+    expect(isValidEstimationScore('?', { scaleType: 'tshirt' })).toBe(true);
+  });
+
+  it('accepts every value of each built-in scale deck', () => {
+    for (const n of ESTIMATION_SCALES.fibonacci.options) {
+      expect(isValidEstimationScore(n)).toBe(true);
+    }
+    for (const n of ESTIMATION_SCALES.doubling.options) {
+      expect(isValidEstimationScore(n, { scaleType: 'doubling' })).toBe(true);
+    }
+    // T-shirt votes arrive as point-mapped numbers, not the size labels.
+    for (const pts of Object.values(ESTIMATION_SCALES.tshirt.pointMapping!)) {
+      expect(isValidEstimationScore(pts, { scaleType: 'tshirt' })).toBe(true);
+    }
+  });
+
+  it('accepts a host-customized T-shirt point value', () => {
+    const settings = { scaleType: 'tshirt' as const, customTshirtMapping: { XS: 2, S: 4, M: 7, L: 11, XL: 20 } };
+    expect(isValidEstimationScore(20, settings)).toBe(true);
+    expect(isValidEstimationScore(7, settings)).toBe(true);
+  });
+
+  it('rejects arbitrary / out-of-range / malformed values that corrupt consensus', () => {
+    for (const bad of [9999999, -100, 0, 7, 1.5, NaN, Infinity, -Infinity]) {
+      expect(isValidEstimationScore(bad)).toBe(false);
+    }
+  });
+
+  it('rejects non-numeric, non-"?" payloads', () => {
+    for (const bad of ['XS', 'abc', '', null, undefined, {}, [], true, () => 1]) {
+      // @ts-expect-error — intentionally passing invalid types
+      expect(isValidEstimationScore(bad)).toBe(false);
+    }
+  });
+});

--- a/shared/gameEvents.ts
+++ b/shared/gameEvents.ts
@@ -661,6 +661,39 @@ export const ESTIMATION_SCALES: Record<EstimationScaleType, EstimationScale> = {
   }
 };
 
+/**
+ * Validates a submitted estimation score on the server. Accepts the abstain
+ * sentinel `'?'` or any numeric value that belongs to a built-in scale deck
+ * (Fibonacci / doubling / T-shirt point mappings) or this lobby's custom
+ * T-shirt mapping. A legitimate client only ever submits a value from its
+ * configured deck — all of which are covered here — so this never rejects a
+ * real vote, while rejecting arbitrary/out-of-range/NaN/non-numeric values
+ * that would corrupt consensus math and the reveal grid. (Security: M-1)
+ */
+export function isValidEstimationScore(
+  score: unknown,
+  settings?: EstimationSettings
+): score is number | '?' {
+  if (score === '?') return true;
+  if (typeof score !== 'number' || !Number.isFinite(score)) return false;
+  for (const scale of Object.values(ESTIMATION_SCALES)) {
+    for (const opt of scale.options) {
+      if (opt === score) return true;
+    }
+    if (scale.pointMapping) {
+      for (const pts of Object.values(scale.pointMapping)) {
+        if (pts === score) return true;
+      }
+    }
+  }
+  if (settings?.customTshirtMapping) {
+    for (const pts of Object.values(settings.customTshirtMapping)) {
+      if (pts === score) return true;
+    }
+  }
+  return false;
+}
+
 export interface CharacterStats {
   str: number; // Strength - Physical damage, HP
   dex: number; // Dexterity - Attack speed, critical chance

--- a/shared/socket-schemas.ts
+++ b/shared/socket-schemas.ts
@@ -716,7 +716,10 @@ export const ClientEventSchemas = {
   revive_start: ReviveTargetPayloadSchema,
   revive_cancel: ReviveTargetPayloadSchema,
   revive_tick: ReviveTargetPayloadSchema,
-  heal_party: HealPartyPayloadSchema,
+  // heal_party carries no payload; the client emits it with no args, so the
+  // wire value is `undefined`. Use the void schema (HealPartyPayloadSchema is
+  // a strict empty-object that would reject `undefined`). (Security: M-2)
+  heal_party: EmptyPayloadSchema,
   player_jump: PlayerJumpPayloadSchema,
   boss_damage_player: BossDamagePlayerPayloadSchema,
   player_projectile: PlayerProjectilePayloadSchema,
@@ -730,6 +733,7 @@ export const ClientEventSchemas = {
   update_estimation_settings: UpdateEstimationSettingsPayloadSchema,
   use_ability: UseAbilityPayloadSchema,
   use_item: UseItemPayloadSchema,
+  client_heartbeat: EmptyPayloadSchema,
 } as const;
 
 /**


### PR DESCRIPTION
Completes the P1 security backlog from the adversarial review. 5 commits, each independently reviewable; full suite green (821 tests); `tsc` clean.

## M-2 — central payload validation gateway *(systemic root cause)*
`ClientEventSchemas` was wired into only 2 of ~48 handlers. Adds an `on(event, handler)` gateway that validates every client event against its registry schema before the handler runs — invalid payloads rejected with `game_error`, never reach game logic. All 47 events route through it; `disconnect` stays raw. Fixed two registry bugs it surfaced (`heal_party` strict-schema-vs-undefined; missing `client_heartbeat`). Contract tests added.

## H-6 — WebSocket rate limiting *(scoped to NOT touch the hot path)*
Per-socket token bucket wired into the gateway, applied **only** to expensive/abusable events (`create_lobby` burst 5 / ~1 per 5s, `join_lobby`, `add_tickets`, settings updates, `reconnect_with_token`, `youtube_play`). **Movement, charge, jump, votes, emotes, attacks are deliberately unlimited** so gameplay responsiveness is unaffected. Skipped under `NODE_ENV=test`. New `TokenBucket`/`SocketRateLimiter` util + unit tests.

## H-5 — lobby cap + idle reaper
- **Cap:** hard `MAX_LOBBIES` (500, env-overridable) → bounds create_lobby flooding.
- **Reaper:** gateway stamps lobby activity on every event; connected clients heartbeat ~25s so active lobbies stay fresh. `reapIdleLobbies()` (every 5 min) removes lobbies idle 30 min (no connected clients), reusing the existing destroy path. Together they bound memory against flooding **and** orphan leaks.

## M-1 — scale-aware `submit_score` validation
Blocks consensus-corrupting values without ever rejecting a legit vote on any scale (incl. custom T-shirt mappings).

## Safety notes
- Schemas are non-`.strict()` (verified) → unknown client fields are stripped, not rejected.
- Rate limits are generous (flood-only) and off the movement path.
- e2e suite gates real client flows before merge.

This closes the High/Medium WS-layer findings. Remaining backlog items (P2/P3: SSR XSS escaping, rollback.yml shell-injection, error-handler leak, team-enum validation, the shell-script fixes) are tracked separately in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)