### PR TITLE
fix(deploy): install drizzle-kit for blue-green migration (3rd devDeps-strip casualty)

### DIFF
--- a/scripts/deploy/deploy-bluegreen.sh
+++ b/scripts/deploy/deploy-bluegreen.sh
@@ -68,7 +68,15 @@ deploy_bluegreen_main() {
   fi
 
   echo "[7/9] Drizzle migration (before swap — preserves rollback semantics; see Pitfall 5)"
-  docker compose -f "$COMPOSE_FILE" --profile "$INACTIVE" run --rm "app-$INACTIVE" npx drizzle-kit push --force
+  # drizzle-kit is a devDependency and is stripped from the runtime image by
+  # `npm ci --omit=dev` (the image ships slim on purpose). A bare `npx
+  # drizzle-kit` installs it into an npx temp dir that drizzle.config.ts's
+  # `import ... from 'drizzle-kit'` cannot resolve ("Cannot find module
+  # 'drizzle-kit'"). Install it into the ephemeral migration container's
+  # /app/node_modules first so it resolves. Keep the version in sync with
+  # package.json devDependencies.
+  docker compose -f "$COMPOSE_FILE" --profile "$INACTIVE" run --rm "app-$INACTIVE" \
+    sh -c 'npm install --no-save --no-audit --no-fund --legacy-peer-deps drizzle-kit@^0.31.10 && npx drizzle-kit push --force'
 
   echo "[8/9] Swap NPM upstream to app-$INACTIVE"
   set +x  # never trace the password even if BASH_XTRACEFD lands enabled


### PR DESCRIPTION
## Why
The manual deploy of `sha-73b9574` got **all the way to the DB migration** — the app booted and passed the blue-green health check (so the vite/nanoid fix from #157 works). It then failed at **[7/9] Drizzle migration**:
```
Cannot find module 'drizzle-kit'
```
Blue-green runs the migration **before** the NPM swap, so it aborted cleanly — **prod stayed on the prior working version** (no outage).

## Root cause
`drizzle-kit` is a `devDependency`, stripped from the runtime image by `npm ci --omit=dev` (the `734d42c` slimming). The migration ran `npx drizzle-kit push`, which installs drizzle-kit into an npx temp dir that `drizzle.config.ts`'s `import … from 'drizzle-kit'` can't resolve. Third casualty of that strip, after **vite** and **nanoid** (#157).

## Fix
Install drizzle-kit into the ephemeral migration container's `/app/node_modules` before `push`, so it resolves. This honors the original "keep it out of the slim image, install at deploy time" design — just into a resolvable location.

```sh
docker compose … run --rm app-$INACTIVE \
  sh -c 'npm install --no-save --no-audit --no-fund --legacy-peer-deps drizzle-kit@^0.31.10 && npx drizzle-kit push --force'
```

## No image rebuild needed
The deploy SSHes to the VPS and `git reset --hard origin/main` before running `deploy-bluegreen.sh`, so once this is on `main` the next deploy picks it up against the already-built `sha-73b9574` image. Bash syntax-checked (`bash -n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)