### PR TITLE
fix(infra): versioned drizzle migrations with gated deploy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,8 @@ shared/api-types.generated.ts linguist-generated=true
 # Shell scripts must keep LF endings on Windows checkouts — they run inside
 # WSL/Linux containers and bash treats CRLF as syntax errors.
 *.sh text eol=lf
+
+# Drizzle migration SQL must stay LF on every platform: `drizzle-kit migrate`
+# records sha256(file bytes) in __drizzle_migrations, so a CRLF rewrite would
+# change the hash and make an already-applied migration look pending.
+migrations/**/*.sql text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,12 @@ COPY --from=builder /app/package*.json ./
 # are not needed at runtime and are a large source of CVEs in the image.
 RUN npm ci --omit=dev --legacy-peer-deps
 
-# Copy drizzle config + schema for db:push
+# Copy drizzle config + schema + migrations for `drizzle-kit migrate` at deploy.
+# The migrations/ folder (SQL + meta journal) MUST be in the image — `migrate`
+# applies these files at runtime, unlike `push` which diffed live and needed none.
 COPY --from=builder /app/drizzle.config.ts ./
 COPY --from=builder /app/shared ./shared
+COPY --from=builder /app/migrations ./migrations
 
 # Set ownership
 RUN chown -R scrumquest:nodejs /app

--- a/migrations/0000_baseline.sql
+++ b/migrations/0000_baseline.sql
@@ -1,3 +1,13 @@
+CREATE TABLE "class_mastery_progress" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"avatar_class" text NOT NULL,
+	"class_xp" integer DEFAULT 0 NOT NULL,
+	"current_tier" text DEFAULT 'Novice' NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "class_mastery_progress_user_id_avatar_class_unique" UNIQUE("user_id","avatar_class")
+);
+--> statement-breakpoint
 CREATE TABLE "estimation_history" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"user_id" integer NOT NULL,
@@ -36,6 +46,8 @@ CREATE TABLE "user_profiles" (
 	"music_volume" real DEFAULT 0.5,
 	"sfx_volume" real DEFAULT 0.7,
 	"settings" json,
+	"total_xp" integer DEFAULT 0 NOT NULL,
+	"current_level" integer DEFAULT 1 NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL,
 	CONSTRAINT "user_profiles_user_id_unique" UNIQUE("user_id")
 );
@@ -50,6 +62,10 @@ CREATE TABLE "user_stats" (
 	"total_damage_dealt" integer DEFAULT 0 NOT NULL,
 	"total_healing" integer DEFAULT 0 NOT NULL,
 	"revives_performed" integer DEFAULT 0 NOT NULL,
+	"total_votes" integer DEFAULT 0 NOT NULL,
+	"consensus_rate" real DEFAULT 0,
+	"avg_voting_speed_ms" integer DEFAULT 0,
+	"total_deaths" integer DEFAULT 0 NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL,
 	CONSTRAINT "user_stats_user_id_unique" UNIQUE("user_id")
 );
@@ -67,6 +83,7 @@ CREATE TABLE "users" (
 	CONSTRAINT "users_email_unique" UNIQUE("email")
 );
 --> statement-breakpoint
+ALTER TABLE "class_mastery_progress" ADD CONSTRAINT "class_mastery_progress_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "estimation_history" ADD CONSTRAINT "estimation_history_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "oauth_accounts" ADD CONSTRAINT "oauth_accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "user_profiles" ADD CONSTRAINT "user_profiles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/migrations/0001_auth0_swap.sql
+++ b/migrations/0001_auth0_swap.sql
@@ -1,0 +1,4 @@
+DROP TABLE "oauth_accounts" CASCADE;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "auth0_sub" text;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_auth0_sub_unique" UNIQUE("auth0_sub");--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "password";

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "e628f3fa-b2fc-4415-8502-274e3097d2da",
-  "prevId": "00000000-0000-0000-0000-000000000000",
+  "id": "df092f89-d379-4876-96bf-e92d4a8556ed",
+  "prevId": "e628f3fa-b2fc-4415-8502-274e3097d2da",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -144,82 +144,6 @@
         "estimation_history_user_id_users_id_fk": {
           "name": "estimation_history_user_id_users_id_fk",
           "tableFrom": "estimation_history",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_accounts": {
-      "name": "oauth_accounts",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "serial",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_account_id": {
-          "name": "provider_account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_accounts_user_id_users_id_fk": {
-          "name": "oauth_accounts_user_id_users_id_fk",
-          "tableFrom": "oauth_accounts",
           "tableTo": "users",
           "columnsFrom": [
             "user_id"
@@ -522,12 +446,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "email": {
           "name": "email",
           "type": "text",
@@ -542,6 +460,12 @@
         },
         "avatar_url": {
           "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth0_sub": {
+          "name": "auth0_sub",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -577,6 +501,13 @@
           "nullsNotDistinct": false,
           "columns": [
             "email"
+          ]
+        },
+        "users_auth0_sub_unique": {
+          "name": "users_auth0_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth0_sub"
           ]
         }
       },

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -5,8 +5,15 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1770100148600,
-      "tag": "0000_sharp_midnight",
+      "when": 1781882457164,
+      "tag": "0000_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781882457165,
+      "tag": "0001_auth0_swap",
       "breakpoints": true
     }
   ]

--- a/scripts/deploy/deploy-bluegreen.sh
+++ b/scripts/deploy/deploy-bluegreen.sh
@@ -68,11 +68,23 @@ deploy_bluegreen_main() {
   fi
 
   echo "[7/9] Drizzle migration (before swap — preserves rollback semantics; see Pitfall 5)"
-  # drizzle-kit is a runtime (deploy-time) dependency — it must be in the image
-  # so `npm ci --omit=dev` keeps it and this resolves. (A deploy-time `npm
-  # install` cannot add it: the container runs NODE_ENV=production, so npm
-  # defaults to --omit=dev and skips it.)
-  docker compose -f "$COMPOSE_FILE" --profile "$INACTIVE" run --rm "app-$INACTIVE" npx drizzle-kit push --force
+  # Versioned migrations via `drizzle-kit migrate`: applies pending journal
+  # entries (migrations/*.sql) non-interactively. We deliberately do NOT use
+  # `push` here — push diffs schema-vs-DB at runtime and can hit interactive
+  # resolvers (e.g. a column rename ambiguity) that have no TTY in CI; in that
+  # state it printed an error yet exited 0, so the schema silently never applied
+  # and the deploy swapped anyway. `migrate` just runs reviewed SQL and exits
+  # non-zero on failure. drizzle-kit is a runtime dependency baked into the image
+  # (npm ci --omit=dev keeps it) so this resolves.
+  #
+  # GATE: a failed migration MUST abort the deploy BEFORE the NPM swap — never
+  # promote an image whose schema did not apply. Check the exit code explicitly
+  # (a bare command under `set -e` proved insufficient once — see above).
+  if ! docker compose -f "$COMPOSE_FILE" --profile "$INACTIVE" run --rm "app-$INACTIVE" npx drizzle-kit migrate; then
+    echo "ERROR: drizzle-kit migrate failed. Aborting WITHOUT NPM swap (old color still serving)." >&2
+    docker compose -f "$COMPOSE_FILE" stop "app-$INACTIVE" || true
+    return 1
+  fi
 
   echo "[8/9] Swap NPM upstream to app-$INACTIVE"
   set +x  # never trace the password even if BASH_XTRACEFD lands enabled


### PR DESCRIPTION
## Why

Follow-up to #160. With drizzle-kit now resolving in the image, the deploy's `drizzle-kit push --force` finally ran — and revealed a second, worse failure: the pending Auth0 schema change (drop `users.password`, add `auth0_sub`, drop `oauth_accounts`) makes `push` hit an **interactive column-conflict resolver**. With no TTY in CI it printed an error, **exited 0**, and the deploy swapped anyway — so the schema silently never applied and `migrate` failures were invisible.

## What

Adopt versioned migrations as the deploy mechanism:

- **Re-baseline `migrations/`** (the old `0000` predated several live tables): `0000_baseline` = the full **pre-Auth0** schema (matches prod exactly today); `0001_auth0_swap` = the Auth0 delta as reviewed SQL.
- **Deploy step [7/9]:** `drizzle-kit push --force` → `drizzle-kit migrate`, now **gated** — a failed migration aborts *before* the NPM swap instead of silently promoting a schema-mismatched image (fixes the silent exit-0 problem).
- **Dockerfile:** bake `migrations/` into the runtime image (`migrate` reads the SQL at deploy; `push` needed none).
- **.gitattributes:** pin `migrations/**/*.sql` to LF so the hash stays stable across platforms.

## Prod prep (already done)

- `drizzle.__drizzle_migrations` baselined: `0000` marked applied (`created_at` = its journal `when`), so this deploy's `migrate` runs **only** `0001`. Verified migrate skips by `created_at` comparison, not hash.
- `0001` SQL validated against prod's live schema inside a rolled-back transaction — applies cleanly. Prod has 0 users / 0 oauth_accounts, so the drops are non-destructive.

## After merge

Docker rebuilds (now with `migrations/`) → deploy → `migrate` applies `0001` → `users.auth0_sub` added, `password`/`oauth_accounts` dropped. Pipeline is non-interactive and gated thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)