### PR TITLE
fix(ci): set optimizeDeps esbuild target so dev:ci pre-bundle works

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,6 +100,14 @@ export default defineConfig({
   // can patch the removed LuminanceFormat import before it's processed.
   optimizeDeps: {
     exclude: ["three-stdlib"],
+    // Match build.target above. Without this, dev pre-bundling falls back to
+    // Vite's default ESBUILD_MODULES_TARGET (chrome87/safari14/es2020/…), which
+    // makes esbuild try to downlevel destructuring it can't ("Transforming
+    // destructuring … is not supported yet") and breaks `dev:ci` — the server
+    // E2E runs against. A modern target needs no destructuring transform.
+    esbuildOptions: {
+      target: ['chrome96', 'firefox95', 'safari15', 'edge96', 'es2022'],
+    },
   },
   // Add support for large models and audio files
   assetsInclude: ["**/*.gltf", "**/*.glb", "**/*.mp3", "**/*.ogg", "**/*.wav"],


### PR DESCRIPTION
## Problem

Playwright E2E was failing with dozens of:

```
✘ [ERROR] Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
is not supported yet
```

`build.target` was already pinned to a modern set to dodge this exact esbuild limitation, but the **dev pre-bundle path** (`optimizeDeps`) had no target override, so it fell back to Vite's default `ESBUILD_MODULES_TARGET` (chrome87/safari14/es2020/…). esbuild can't downlevel destructuring to that floor, so `npm run dev:ci` — the server Playwright E2E runs against — never started, breaking the whole suite.

## Fix

Pin `optimizeDeps.esbuildOptions.target` to the same modern set as `build.target`.

## Verified

Locally reproduced the error, applied the fix, re-ran `dev:ci`: **0** transform errors, server logs `serving on port 5000`. Unit suite still 821/821.

Independent of #160/#161 (deploy/migrations) — this is dev/CI-only; the production Rollup build was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)