### PR TITLE
fix(infra): serve index.html with no-store to stop post-deploy reload loop

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -107,7 +107,17 @@ export function serveStatic(app: Express) {
       // Inject SEO meta tags for social media crawlers
       const requestPath = req.originalUrl.split('?')[0]; // Strip query params
       const processed = injectMetaTags(cachedHtml, requestPath);
-      res.status(200).set({ "Content-Type": "text/html" }).end(processed);
+      // The entry HTML references hashed chunk filenames that change every
+      // deploy. It MUST NOT be cached: a stale index.html points at chunk
+      // hashes that 404 after a deploy, which fires Vite's `vite:preloadError`
+      // and traps users on the "Scrum Monsters was updated / Reload" screen —
+      // reload just re-serves the cached stale HTML. `no-store` forces every
+      // navigation/reload to fetch fresh HTML with the current hashes. (Hashed
+      // assets under /assets are immutable and stay long-cached.)
+      res.status(200).set({
+        "Content-Type": "text/html",
+        "Cache-Control": "no-store, must-revalidate",
+      }).end(processed);
     } catch (_error) {
       res.status(500).send('Internal Server Error');
     }


### PR DESCRIPTION
## Symptom (prod)

User couldn't create a lobby — got the **"Scrum Monsters was updated / A new version is available. Reload to continue."** screen on every attempt.

## Diagnosis

- **Server-side lobby works** — prod logs show `Lobby created` each time, immediately followed by a `client namespace disconnect` (the page reloading).
- **The deployed build is internally consistent** — `index.html`'s entry chunks *and* all 9 lazy route chunks return 200. Not a broken deploy.
- The "updated" screen is the React Router error fallback (`client/src/routes.tsx`) that fires on Vite's `vite:preloadError` — a lazy chunk hash that no longer exists.
- **Root cause:** `server/vite.ts` served the SPA entry HTML with only `Content-Type` and **no `Cache-Control`**, so browsers heuristically cached it. After today's deploys, a stale cached `index.html` pointed at old chunk hashes → 404 → `preloadError`. The reload re-served the same cached stale HTML → loop.

## Fix

Serve the entry HTML with `Cache-Control: no-store, must-revalidate` so every navigation/reload fetches fresh HTML referencing the current chunk hashes. Hashed `/assets/*` stay immutable + long-cached (unchanged).

## Verified

- Reproduced the missing header against prod (`curl -D-` on `/` showed no `Cache-Control`).
- Confirmed current build consistency (entry + lazy chunks all 200).
- Typecheck clean; unit suite 821/821.

Note: no existing `serveStatic` test harness (it reads a built `dist/public`), so no unit test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)