### PR TITLE
fix(api): escape lobbyId in SSR meta tags to close reflected XSS

### DIFF
--- a/server/seoMiddleware.test.ts
+++ b/server/seoMiddleware.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { injectMetaTags } from "./seoMiddleware";
+
+const TEMPLATE = "<html><head><title>x</title></head><body></body></html>";
+
+describe("injectMetaTags XSS escaping", () => {
+  it("escapes a script-injection payload in the /game/:lobbyId path", () => {
+    const evil = '/game/"><script>alert(1)</script>';
+    const out = injectMetaTags(TEMPLATE, evil);
+    // The raw breakout sequence must never appear in the output.
+    expect(out).not.toContain('"><script>alert(1)</script>');
+    expect(out).not.toContain("<script>alert(1)</script>");
+    // It must be HTML-attribute-escaped instead.
+    expect(out).toContain("&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("escapes the lobbyId where it flows into title/og:title", () => {
+    const out = injectMetaTags(TEMPLATE, '/game/<img src=x onerror=alert(1)>');
+    expect(out).not.toContain("<img src=x onerror=alert(1)>");
+    expect(out).toContain("&lt;img src=x onerror=alert(1)&gt;");
+  });
+
+  it("renders the expected static title for a known route", () => {
+    const out = injectMetaTags(TEMPLATE, "/about");
+    expect(out).toContain("About Scrum Monsters");
+    expect(out).toContain('<link rel="canonical" href="https://scrummonsters.com/about" />');
+  });
+
+  it("emits a clean canonical/og:url for the home route", () => {
+    const out = injectMetaTags(TEMPLATE, "/");
+    expect(out).toContain('content="https://scrummonsters.com" />');
+  });
+});

--- a/server/seoMiddleware.ts
+++ b/server/seoMiddleware.ts
@@ -74,24 +74,30 @@ function getMetaForPath(path: string): MetaConfig {
 
 export function injectMetaTags(html: string, requestPath: string): string {
   const meta = getMetaForPath(requestPath);
-  // requestPath is user-controlled (req.originalUrl); escape before
-  // embedding into href / content attributes.
+  // EVERY interpolated value below is user-influenced: requestPath comes from
+  // req.originalUrl, and meta.title/description embed the path-derived lobbyId
+  // for /game/:lobbyId routes (see getMetaForPath). All of them must be
+  // HTML-attribute-escaped before landing in <title>/content="…"/href="…",
+  // or `/game/"><script>…` breaks out of the attribute. CodeQL js/reflected-xss.
   const safePath = escapeHtmlAttr(requestPath === '/' ? '' : requestPath);
   const canonicalUrl = `${SITE_URL}${safePath}`;
-  const ogImage = meta.ogImage || DEFAULT_OG_IMAGE;
+  const title = escapeHtmlAttr(meta.title);
+  const description = escapeHtmlAttr(meta.description);
+  const ogType = escapeHtmlAttr(meta.ogType || 'website');
+  const ogImage = escapeHtmlAttr(meta.ogImage || DEFAULT_OG_IMAGE);
 
   const metaTags = `
-    <title>${meta.title}</title>
-    <meta name="description" content="${meta.description}" />
-    <meta property="og:type" content="${meta.ogType || 'website'}" />
+    <title>${title}</title>
+    <meta name="description" content="${description}" />
+    <meta property="og:type" content="${ogType}" />
     <meta property="og:site_name" content="${SITE_NAME}" />
-    <meta property="og:title" content="${meta.title}" />
-    <meta property="og:description" content="${meta.description}" />
+    <meta property="og:title" content="${title}" />
+    <meta property="og:description" content="${description}" />
     <meta property="og:image" content="${ogImage}" />
     <meta property="og:url" content="${canonicalUrl}" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="${meta.title}" />
-    <meta name="twitter:description" content="${meta.description}" />
+    <meta name="twitter:title" content="${title}" />
+    <meta name="twitter:description" content="${description}" />
     <meta name="twitter:image" content="${ogImage}" />
     <link rel="canonical" href="${canonicalUrl}" />`;
 


### PR DESCRIPTION
## Security — closes CodeQL js/reflected-xss (#269, #25)

While triaging all open code-scanning alerts, found that the two **high-severity reflected-XSS** alerts in `server/vite.ts` are **real**, not false positives.

`injectMetaTags` escaped the request *path* into `og:url`/`canonical`, but for `/game/:lobbyId` routes the user-controlled `lobbyId` flows **unescaped** through `getMetaForPath` into `meta.title`, which is then injected into `<title>` and `content="${meta.title}"`. A request like:

```
/game/"><script>alert(1)</script>
```

breaks out of the attribute and injects script → reflected XSS served from the app origin.

## Fix

Escape every user-influenced value (`title`, `description`, `ogType`, `ogImage`) with the existing `escapeHtmlAttr` before interpolation. Static route titles/descriptions contain no HTML-special chars, so escaping them is a no-op — only the `/game/:lobbyId`-derived values change behavior.

## Tests

Adds `server/seoMiddleware.test.ts` (4 cases): `"><script>` and `<img onerror>` payloads in `lobbyId` are escaped; static routes still render correctly. Full suite 825/825.

## Other alerts (FYI, not in this PR)
- **#325 medium log-injection** — already mitigated (`log()` strips CR/LF/control chars); stale/unrecognized-sanitizer.
- **55 Trivy** — container base-image + dependency CVEs; remediated by image/dep bumps, separate from code. Can tackle as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)