### PR TITLE
fix(game): stop avatar-confirm crash from YouTube API replacing a React node

### DIFF
--- a/client/src/components/ui/YoutubeAudioPlayer.tsx
+++ b/client/src/components/ui/YoutubeAudioPlayer.tsx
@@ -46,7 +46,16 @@ declare global {
 export function YoutubeAudioPlayer() {
   const { setYoutubePlayer, stopYoutubeAudio } = useAudio();
   const playerRef = useRef<YTPlayer | null>(null);
+  // `containerRef` is the React-owned wrapper that stays mounted. `mountRef` is
+  // a throwaway inner node we hand to the YouTube IFrame API. The API REPLACES
+  // the element it's given with an <iframe>; if we hand it the React-managed
+  // node, that node vanishes from the DOM and React's sibling references in the
+  // parent (GamePage's fragment) go stale — the next sibling reorder commits an
+  // insertBefore against a node that's "not a child", crashing the whole tree
+  // (the avatar→lobby transition). Giving the API a nested child to consume
+  // keeps the outer node React-stable.
   const containerRef = useRef<HTMLDivElement>(null);
+  const mountRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Load YouTube IFrame API
@@ -65,9 +74,9 @@ export function YoutubeAudioPlayer() {
     };
 
     const initializePlayer = () => {
-      if (!containerRef.current) return;
+      if (!mountRef.current) return;
 
-      playerRef.current = new window.YT.Player(containerRef.current, {
+      playerRef.current = new window.YT.Player(mountRef.current, {
         height: '0',
         width: '0',
         playerVars: {
@@ -105,10 +114,14 @@ export function YoutubeAudioPlayer() {
   }, [setYoutubePlayer, stopYoutubeAudio]);
 
   return (
-    <div 
+    <div
       ref={containerRef}
       className="absolute opacity-0 pointer-events-none"
       style={{ left: '-9999px', top: '-9999px' }}
-    />
+    >
+      {/* The YouTube IFrame API replaces THIS inner node with its <iframe>,
+          leaving the React-owned wrapper above untouched. */}
+      <div ref={mountRef} />
+    </div>
   );
 }


### PR DESCRIPTION
## Prod outage — users can't get past avatar selection

Clicking **Confirm Avatar** crashed the entire GamePage tree:
```
NotFoundError: Failed to execute 'insertBefore' on 'Node':
The node before which the new node is to be inserted is not a child of this node.
React Router caught the following error during render
```
React Router's error boundary then renders the **"Scrum Monsters was updated / Reload to continue"** screen — which *looked* like a stale-chunk loop but is actually a hard render crash. It survives cache-clears and reloads.

## Reproduced deterministically

In a **clean headless browser** against prod, and locally (unminified): create lobby → Confirm Avatar → crash, every time. Unminified stack pinned it to `GamePage`'s `<Fragment>` at the `<Suspense>` boundary during `commitPlacement → insertBefore`.

## Root cause

`YoutubeAudioPlayer` passed its own React-managed `<div>` to `new YT.Player(el)`. **The YouTube IFrame API replaces the element you give it with an `<iframe>`** — so React's node silently leaves the DOM. That node is a sibling in GamePage's fragment; when the avatar→lobby swap (mounting the R3F `<Canvas>`) commits an `insertBefore` relative to it, the node is "not a child" → React throws and tears down the tree.

## Fix

Hand the API a **nested throwaway inner `<div>`** to consume; keep the React-owned wrapper stable. The iframe now lives *inside* the wrapper, outside React's sibling tracking.

## Verified end-to-end

Local repro before fix: 3 console errors + error screen. After fix: **0 errors**, avatar→lobby transitions cleanly, lobby renders (Battle Teams, player list, Ready Up). Typecheck clean; 821/821 unit tests.

Follow-up worth considering: an E2E test covering create-lobby → confirm-avatar → lobby (no test caught this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)