### PR TITLE
chore(monitoring): probe talesofaneria.com, enable Prometheus live reload

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -140,6 +140,12 @@ services:
       - '--storage.tsdb.retention.time=7d'
       - '--storage.tsdb.retention.size=512MB'
       - '--storage.tsdb.path=/prometheus'
+      # Enables POST /-/reload. Without it that endpoint 404s and a
+      # prometheus.yml edit silently does nothing until the container is
+      # restarted — which is how the 2026-05-16 config changes sat
+      # dormant for three months. Prometheus is bound to 127.0.0.1:9090,
+      # so the lifecycle endpoints are not reachable from the internet.
+      - '--web.enable-lifecycle'
     deploy:
       resources:
         limits:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -31,6 +31,7 @@ scrape_configs:
           - https://scrummonsters.com
           - https://prestonfarr.com
           - https://familytokens.app
+          - https://talesofaneria.com
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
Two small monitoring changes. Both are **already applied by hand on the VPS and verified working** — this PR exists so they survive, because `deploy-lightsail.yml` runs `git reset --hard origin/main` over `/opt/scrummonsters` and will otherwise erase them on the next ScrumMonsters deploy.

### 1. Probe `talesofaneria.com`

Tales of Aneria migrated off Replit onto this box on 2026-08-19 (container `toa-app`, port 5002, NPM proxy host id=5). It was the only tenant with no uptime or TLS-expiry signal. Adding it to `blackbox-tls` brings it under the existing `TLSCertExpiringSoon` (<14d) and `TLSCertExpiryCritical` (<7d) rules.

### 2. `--web.enable-lifecycle`

This one is worth reading even if you skip the rest.

Prometheus started **2026-05-12**. `prometheus.yml` was last edited **2026-05-16**. There is no lifecycle flag, so `POST /-/reload` 404s and the only way to apply a config change is restarting the container — which never happened.

The consequence: for three months the config file listed `prestonfarr.com`, `familytokens.app`, a `node` job and a `postgres` job that the running Prometheus **had never loaded**. Reading the file suggested those were monitored. They were not. Only `scrummonsters.com` was actually being probed.

Restarting the container on 2026-08-19 took active targets from 3 to 8. `node-exporter` and `postgres-exporter` were already defined in `docker-compose.prod.yml` and simply had never been started; both are now up (~20MB and ~5MB against their 32M limits).

This flag also exposes `/-/quit`, but Prometheus publishes only on `127.0.0.1:9090`, so both lifecycle endpoints already require shell access on the host.

### Verified on the VPS before opening this

- `docker compose config` parses
- `POST /-/reload` returns **200** (was 404)
- **7/8 targets up** — all four sites, `node`, `postgres`, `app-blue`; `app-green` is down by design under blue-green
- remote_write to Grafana Cloud resumed cleanly, 0 failed samples
- No other tenant's proxy host, certificate or container was touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tsdrhRkomE6YSTZymJxdA